### PR TITLE
Update CVT description to include producer contract testing

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Contract Validator Toolkit',
-  tagline: 'Consumer-based contract validation for OpenAPI specifications',
+  tagline: 'Consumer and producer contract validation for OpenAPI specifications',
   favicon: 'img/favicon.ico',
 
   // Production URL

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -80,7 +80,7 @@ export default function Home(): React.JSX.Element {
   return (
     <Layout
       title={`Home`}
-      description="Consumer-based contract validation for OpenAPI specifications">
+      description="Consumer and producer contract validation for OpenAPI specifications">
       <HomepageHeader />
       <main>
         <section className={styles.features}>

--- a/docs/internal/prd.md
+++ b/docs/internal/prd.md
@@ -9,7 +9,7 @@ description: Complete product, architectural, and implementation requirements fo
 
 ## 1. Overview
 
-This document defines the product, architectural, and implementation requirements for the **Contract Validator Toolkit (CVT)** — a consumer-based contract validation platform for OpenAPI v2 and v3 specifications. CVT is built using **Go**, exposes a **gRPC-first interface**, and runs entirely via **Docker**
+This document defines the product, architectural, and implementation requirements for the **Contract Validator Toolkit (CVT)** — a consumer- and producer-based contract validation platform for OpenAPI v2 and v3 specifications. CVT is built using **Go**, exposes a **gRPC-first interface**, and runs entirely via **Docker**
 
 ## 2. Definitions
 
@@ -18,9 +18,9 @@ This document defines the product, architectural, and implementation requirement
 | Term                                | Definition                                                                                                                                                          |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Consumer-based Contract Testing** | Validation initiated by an API consumer to ensure that requests and responses conform to a published OpenAPI contract.                                              |
-| **Producer-based Contract Testing** | Validation performed by an API provider to ensure their implementation conforms to the contract. _(Out of scope for initial releases; planned for a future phase.)_ |
+| **Producer-based Contract Testing** | Validation performed by an API provider to ensure their implementation conforms to the contract. |
 
-### CVT focuses only on consumer-based contract testing for initial phases
+### CVT supports both consumer and producer contract testing
 
 ## 3. Problem Statement
 
@@ -80,7 +80,7 @@ flowchart LR
 
 ## 4. Goals and Objectives
 
-- **Focus on consumer-based contract testing** for OpenAPI v2 and v3.
+- **Focus on consumer- and producer-based contract testing** for OpenAPI v2 and v3.
 - **SDKs are not test frameworks** — users continue to use existing testing libraries like Jest, Pytest, or JUnit.
 - **SDKs handle communication and orchestration only**: gRPC protocol handling, configuration, authentication, and result retrieval.
 - Maintain **uniform and simple SDK functionality** across Node, Python, Go, and Java.


### PR DESCRIPTION
## Summary

- Updates all documentation that described CVT as "consumer-based only" to reflect that it now supports both consumer and producer contract testing
- Removes outdated "out of scope" note for producer-based testing since it's now implemented
- Updates site tagline and meta descriptions for consistency

## Changes

**`docs/internal/prd.md`**:
- Updated overview to "consumer- and producer-based contract validation platform"
- Removed "(Out of scope for initial releases; planned for a future phase.)" from producer testing definition
- Changed section header from "CVT focuses only on consumer-based..." to "CVT supports both consumer and producer contract testing"
- Updated goals section to include producer-based testing

**`docs-site/docusaurus.config.ts`**:
- Updated tagline to "Consumer and producer contract validation for OpenAPI specifications"

**`docs-site/src/pages/index.tsx`**:
- Updated meta description to match new tagline

## Test plan

- [x] Docs site builds successfully (`pnpm build`)
- [x] Verified no remaining problematic "consumer-based only" references
- [x] Only remaining "consumer-based" text is in definitions table (intentional - defines the term)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product messaging and documentation to reflect support for both consumer and producer contract validation for OpenAPI specifications, expanding the scope from consumer-only focus.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->