### PR TITLE
Align intro.md with installation and quick-start guides

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -47,17 +47,16 @@ make run-server
 Node.js and Python SDKs are installed from a local clone (not yet published to package registries). The Go SDK can be installed directly from GitHub:
 
 ```bash
-# Clone the repository
+# Clone the repository into your project directory
 git clone https://github.com/sahina/cvt.git
-cd your-project
 
-# Node.js (from local path, assumes cvt was cloned as a sibling directory)
-pnpm add ../cvt/sdks/node
+# Node.js (from local clone)
+pnpm add ./cvt/sdks/node
 
-# Python (from local path)
-pip install ../cvt/sdks/python
+# Python (from local clone)
+pip install ./cvt/sdks/python
 
-# Go (from GitHub)
+# Go (from GitHub - no local clone needed)
 go get github.com/sahina/cvt/sdks/go
 ```
 


### PR DESCRIPTION
## Summary
- Fix SDK install commands to show local clone installation (SDKs not published to npm/PyPI)
- Update example to use Petstore schema and Pet response body
- Add note about saving Petstore schema as ./openapi.json
- Add link to Installation guide for detailed instructions

## Test plan
- [x] Verified intro example matches quick-start patterns
- [x] Verified install instructions match installation.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added local-clone installation workflow for Node.js and Python and a GitHub-based install option for Go; added link to a dedicated Installation page.
  * Updated interaction validation examples to use the Petstore schema, validate GET /pet/123, remove request headers, and show the updated Pet request/response shape.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->