### PR TITLE
docs: move demo repository link to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A contract validation platform for OpenAPI v2/v3 specifications that validates API requests and responses against API contracts. Supports both consumer-side (client) and producer-side (server) validation.
 
+> For complete working examples with real-world usage patterns:
+>
+> [CVT Demo Repository](https://github.com/sahina/cvt-demo).
+
 ## Understanding Consumer vs Producer Validation
 
 CVT supports two complementary validation approaches. Understanding when to use each is key to effective contract testing.
@@ -428,7 +432,6 @@ make down
 ```
 
 > **Note**: The Docker setup includes PostgreSQL for persistent storage. Schemas and consumer registrations survive server restarts.
-> **Demo Repository**: For a complete working example with real-world usage patterns, see the [CVT Demo Repository](https://github.com/sahina/cvt-demo).
 
 ### Consumer Validation (Client SDK)
 


### PR DESCRIPTION
## Summary
- Moves the CVT Demo Repository reference to a prominent position right after the project description
- Removes the duplicate reference from the Quick Start section
- Improves visibility of the demo repository for new users

## Test plan
- [x] Verify the demo link appears at the top of the README
- [x] Verify the duplicate link was removed from Quick Start section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive section to README showcasing complete working examples with real-world usage patterns.
  * Reorganized demo repository reference for improved discoverability at the top of documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->