### PR TITLE
docs: update Node.js SDK package name to @sahina/cvt-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ make down
 ### Basic Usage
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("my-api", "./openapi.json");

--- a/ci-templates/README.md
+++ b/ci-templates/README.md
@@ -183,7 +183,7 @@ Auto-generate fixtures for new endpoints:
 ### Jest (Node.js)
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 describe("API Contract Tests", () => {
   let validator: ContractValidator;

--- a/docs/ai-helper/advanced-patterns.md
+++ b/docs/ai-helper/advanced-patterns.md
@@ -216,7 +216,7 @@ If you already have tests, add contract validation:
 ```typescript
 // jest.setup.ts
 import fs from 'fs';
-import { ContractValidator } from '@cvt/sdk';
+import { ContractValidator } from '@sahina/cvt-sdk';
 
 let validator: ContractValidator;
 

--- a/docs/ai-helper/context-templates.md
+++ b/docs/ai-helper/context-templates.md
@@ -90,7 +90,7 @@ Fetch CVT documentation from:
 ## SDK
 
 Using [Node.js/Python/Go/Java] SDK. Import from:
-- Node.js: @cvt/sdk
+- Node.js: @sahina/cvt-sdk
 - Python: cvt_sdk
 - Go: github.com/sahina/cvt/sdks/go/cvt
 - Java: com.cvt.sdk
@@ -191,7 +191,7 @@ For highly restricted environments, embed the essential information directly:
 ### Node.js SDK
 
 ```typescript
-import { ContractValidator } from '@cvt/sdk';
+import { ContractValidator } from '@sahina/cvt-sdk';
 
 const validator = new ContractValidator('localhost:9550');
 await validator.registerSchema('api-name', schemaContent);

--- a/docs/ai-helper/overview.md
+++ b/docs/ai-helper/overview.md
@@ -99,7 +99,7 @@ AI: I'll help you set up CVT. Based on the CVT documentation, here's what we nee
    docker run -d -p 9550:9550 ghcr.io/cvt/cvt-server:latest
 
 2. Install the Node.js SDK (see installation guide for details):
-   npm install @cvt/sdk
+   npm install @sahina/cvt-sdk
 
 3. Create your first contract test...
 ```

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -316,7 +316,7 @@ npm run build
 npm link
 
 # In your consumer project
-npm link @cvt/sdk
+npm link @sahina/cvt-sdk
 ```
 
 ### Python - Editable Install

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -165,7 +165,7 @@ grpc-health-probe -addr=localhost:9550
   <TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 const validator = new ContractValidator("localhost:9550");
 console.log("Connected!");
 ```

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -48,7 +48,7 @@ curl http://localhost:9551/metrics
 Create a test file `contract.test.ts`:
 
 ```typescript
-import { ContractValidator } from '@cvt/sdk';
+import { ContractValidator } from '@sahina/cvt-sdk';
 import * as path from 'path';
 
 describe('Petstore API Contract', () => {
@@ -361,7 +361,7 @@ Automatically validate all HTTP traffic:
 
 ```typescript
 import axios from 'axios';
-import { createAxiosAdapter } from '@cvt/sdk/adapters';
+import { createAxiosAdapter } from '@sahina/cvt-sdk/adapters';
 
 const api = axios.create({ baseURL: 'http://api.example.com' });
 const adapter = createAxiosAdapter({ axios: api, validator, autoValidate: true });

--- a/docs/guides/breaking-changes.mdx
+++ b/docs/guides/breaking-changes.mdx
@@ -85,7 +85,7 @@ Result: INCOMPATIBLE (2 breaking changes)
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -68,7 +68,7 @@ make run-server
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 describe("Petstore Contract", () => {
   let validator: ContractValidator;
@@ -224,7 +224,7 @@ Build request/response objects and validate them directly:
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -350,7 +350,7 @@ Wrap your HTTP client for automatic validation of all requests/responses:
 
 ```typescript
 import axios from "axios";
-import { ContractValidator, createAxiosAdapter } from "@cvt/sdk";
+import { ContractValidator, createAxiosAdapter } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -463,7 +463,7 @@ Use the mock adapter for tests without a real API:
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator, createMockAdapter } from "@cvt/sdk";
+import { ContractValidator, createMockAdapter } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -592,7 +592,7 @@ Register from captured test interactions - endpoints and fields are extracted au
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator, createMockAdapter } from "@cvt/sdk";
+import { ContractValidator, createMockAdapter } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -1274,7 +1274,7 @@ CVT supports TLS and API key authentication for production deployments.
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator({
   address: "cvt.internal:9550",

--- a/docs/guides/producer-testing.mdx
+++ b/docs/guides/producer-testing.mdx
@@ -108,7 +108,7 @@ sequenceDiagram
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ProducerTestKit } from "@cvt/sdk/producer";
+import { ProducerTestKit } from "@sahina/cvt-sdk/producer";
 
 describe("Petstore API", () => {
   let testKit: ProducerTestKit;
@@ -346,7 +346,7 @@ sequenceDiagram
 <TabItem value="express" label="Express">
 
 ```typescript
-import { createExpressMiddleware } from "@cvt/sdk/producer";
+import { createExpressMiddleware } from "@sahina/cvt-sdk/producer";
 
 app.use(
   createExpressMiddleware({
@@ -361,7 +361,7 @@ app.use(
 <TabItem value="fastify" label="Fastify">
 
 ```typescript
-import { fastifyProducerPlugin } from "@cvt/sdk/producer";
+import { fastifyProducerPlugin } from "@sahina/cvt-sdk/producer";
 
 fastify.register(fastifyProducerPlugin, { schemaId: "petstore", validator });
 ```

--- a/docs/guides/validation-modes.mdx
+++ b/docs/guides/validation-modes.mdx
@@ -114,7 +114,7 @@ Each SDK uses language-appropriate naming conventions:
   <TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
-import { createExpressMiddleware } from "@cvt/sdk/producer";
+import { createExpressMiddleware } from "@sahina/cvt-sdk/producer";
 
 app.use(
   createExpressMiddleware({

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -67,7 +67,7 @@ See [Installation](./getting-started/installation.mdx) for detailed instructions
 Save the [Petstore OpenAPI schema](https://petstore3.swagger.io/api/v3/openapi.json) as `./openapi.json`, then:
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 

--- a/docs/reference/sdk/index.mdx
+++ b/docs/reference/sdk/index.mdx
@@ -125,7 +125,7 @@ All SDKs provide:
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 ```

--- a/docs/reference/sdk/nodejs.md
+++ b/docs/reference/sdk/nodejs.md
@@ -28,7 +28,7 @@ pnpm add ./cvt/sdks/node
 ## Quick Start
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 
@@ -224,8 +224,8 @@ Automatically validate all Axios requests:
 
 ```typescript
 import axios from "axios";
-import { ContractValidator } from "@cvt/sdk";
-import { createAxiosAdapter } from "@cvt/sdk/adapters";
+import { ContractValidator } from "@sahina/cvt-sdk";
+import { createAxiosAdapter } from "@sahina/cvt-sdk/adapters";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -255,8 +255,8 @@ adapter.detach();
 ### Fetch Adapter
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
-import { createFetchAdapter } from "@cvt/sdk/adapters";
+import { ContractValidator } from "@sahina/cvt-sdk";
+import { createFetchAdapter } from "@sahina/cvt-sdk/adapters";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
@@ -280,8 +280,8 @@ const interactions = adapter.getInteractions();
 
 ```typescript
 import express from "express";
-import { ContractValidator } from "@cvt/sdk";
-import { createExpressMiddleware } from "@cvt/sdk/producer";
+import { ContractValidator } from "@sahina/cvt-sdk";
+import { createExpressMiddleware } from "@sahina/cvt-sdk/producer";
 
 const app = express();
 app.use(express.json());
@@ -311,8 +311,8 @@ app.get("/pet/:petId", (req, res) => {
 
 ```typescript
 import Fastify from "fastify";
-import { ContractValidator } from "@cvt/sdk";
-import { fastifyProducerPlugin } from "@cvt/sdk/producer";
+import { ContractValidator } from "@sahina/cvt-sdk";
+import { fastifyProducerPlugin } from "@sahina/cvt-sdk/producer";
 
 const fastify = Fastify();
 const validator = new ContractValidator("localhost:9550");
@@ -330,7 +330,7 @@ fastify.register(fastifyProducerPlugin, {
 Test your API responses against your schema without real consumers:
 
 ```typescript
-import { ProducerTestKit } from "@cvt/sdk/producer";
+import { ProducerTestKit } from "@sahina/cvt-sdk/producer";
 
 describe("Pet API", () => {
   let testKit: ProducerTestKit;
@@ -378,7 +378,7 @@ describe("Pet API", () => {
 Build consumer registrations from captured mock interactions:
 
 ```typescript
-import { createMockAdapter } from "@cvt/sdk/adapters";
+import { createMockAdapter } from "@sahina/cvt-sdk/adapters";
 
 // Capture interactions during tests
 const mock = createMockAdapter({ validator, cache: true });
@@ -485,7 +485,7 @@ import {
   RegisterConsumerOptions,
   ConsumerInfo,
   CanIDeployResult,
-} from "@cvt/sdk";
+} from "@sahina/cvt-sdk";
 ```
 
 ## Error Handling

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ CVT enables API contract testing by:
 ### Node.js
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("user-api", "./openapi.json");
@@ -103,13 +103,13 @@ cvt can-i-deploy --schema my-api --version 2.0.0 --env prod --server localhost:9
 ### Installation
 
 ```bash
-npm install @cvt/sdk
+npm install @sahina/cvt-sdk
 ```
 
 ### Initialization
 
 ```typescript
-import { ContractValidator, ContractValidatorOptions, TLSOptions } from "@cvt/sdk";
+import { ContractValidator, ContractValidatorOptions, TLSOptions } from "@sahina/cvt-sdk";
 
 // Simple connection
 const validator = new ContractValidator("localhost:9550");

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -18,10 +18,10 @@ cd ../your-project
 npm install ../sdks/node
 ```
 
-For the published version (once available):
+For the published version via GitHub Packages:
 
 ```bash
-npm install @cvt/sdk
+npm install @sahina/cvt-sdk
 ```
 
 ## Usage
@@ -31,7 +31,7 @@ npm install @cvt/sdk
 You can register a schema from a local file or a URL.
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 import * as path from "path";
 
 const validator = new ContractValidator();
@@ -60,7 +60,7 @@ import {
   ContractValidator,
   ValidationRequest,
   ValidationResponse,
-} from "@cvt/sdk";
+} from "@sahina/cvt-sdk";
 
 interface User {
   username: string;
@@ -108,7 +108,7 @@ The SDK includes an Axios adapter for automatic HTTP traffic validation:
 
 ```typescript
 import axios from "axios";
-import { ContractValidator, createAxiosAdapter } from "@cvt/sdk";
+import { ContractValidator, createAxiosAdapter } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator();
 await validator.registerSchema("petstore", "./openapi.json");
@@ -159,8 +159,8 @@ Validate incoming requests and outgoing responses against your OpenAPI contract 
 ### Express Middleware
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
-import { createExpressMiddleware } from "@cvt/sdk/producer";
+import { ContractValidator } from "@sahina/cvt-sdk";
+import { createExpressMiddleware } from "@sahina/cvt-sdk/producer";
 
 const validator = new ContractValidator();
 await validator.registerSchema("my-api", "./openapi.json");
@@ -178,7 +178,7 @@ app.use(
 ### Fastify Plugin
 
 ```typescript
-import { fastifyProducerPlugin } from "@cvt/sdk/producer";
+import { fastifyProducerPlugin } from "@sahina/cvt-sdk/producer";
 
 fastify.register(fastifyProducerPlugin, {
   schemaId: "my-api",
@@ -204,7 +204,7 @@ fastify.register(fastifyProducerPlugin, {
 Detect breaking changes between OpenAPI schema versions before deployment:
 
 ```typescript
-import { ContractValidator } from "@cvt/sdk";
+import { ContractValidator } from "@sahina/cvt-sdk";
 
 const validator = new ContractValidator();
 
@@ -253,7 +253,7 @@ Test that your API handlers return responses matching your OpenAPI specification
 ### ProducerTestKit
 
 ```typescript
-import { ProducerTestKit } from "@cvt/sdk/producer";
+import { ProducerTestKit } from "@sahina/cvt-sdk/producer";
 
 const testKit = new ProducerTestKit({
   schemaId: "user-api",


### PR DESCRIPTION
## Summary

- Rename all `@cvt/sdk` references to `@sahina/cvt-sdk` across 17 documentation files to match the published GitHub Packages scope
- Update Node.js SDK README installation instructions to reflect published package name

## Test plan

- [ ] Verify no remaining `@cvt/sdk` references: `grep -r "@cvt/sdk" --include="*.md" --include="*.mdx" --include="*.txt" --include="*.ts"`