### PR TITLE
Add CLI binary publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,3 +204,55 @@ jobs:
           prerelease: ${{ needs.validate.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-cli:
+    name: Build CLI (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: [validate, release]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Build binary
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          COMMIT="${{ github.sha }}"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            EXT=".exe"
+          fi
+          OUTPUT="cvt-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}"
+
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -trimpath \
+            -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${DATE}" \
+            -o "${OUTPUT}" ./cmd/cvt
+        env:
+          CGO_ENABLED: '0'
+
+      - name: Generate checksum
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            EXT=".exe"
+          fi
+          BINARY="cvt-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}"
+          sha256sum "${BINARY}" > "${BINARY}.sha256"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            cvt-${{ matrix.goos }}-${{ matrix.goarch }}*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `build-cli` job to the release workflow that cross-compiles CVT CLI binaries for 6 platform/arch combos (linux/darwin/windows x amd64/arm64)
- Injects version, commit, and build date via ldflags into the existing placeholders in `cmd/cvt/main.go`
- Generates SHA256 checksum files and uploads all 12 assets (6 binaries + 6 checksums) to the GitHub Release

## Test plan

- [ ] Push a pre-release tag (e.g. `v0.x.x-rc.1`) and verify 12 new assets appear on the GitHub Release
- [ ] Download a binary and run `./cvt version` to confirm version/commit/date are injected
- [ ] Verify checksum: `sha256sum -c cvt-<os>-<arch>.sha256`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-built command-line binaries are now automatically generated and published with each release, supporting Linux, macOS, and Windows on both Intel/AMD and ARM processor architectures.
  * SHA-256 checksums are provided with each binary to enable users to verify download integrity and authenticity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->