### PR TITLE
docs: update SDK installation instructions to reflect published packages

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -59,32 +59,41 @@ Install the SDK for your language:
 <Tabs groupId="sdk-language">
   <TabItem value="nodejs" label="Node.js" default>
 
-**The Node.js SDK is not published to npm. Install from a local clone:**
+**GitHub Packages (recommended)** — single PAT covers both Node.js and Java SDKs:
+
+1. Create a GitHub [Personal Access Token](https://github.com/settings/tokens) with `read:packages` scope
+2. Add a `.npmrc` file to your project root (or `~/.npmrc` for global config):
+
+    ```text
+    @sahina:registry=https://npm.pkg.github.com
+    //npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+    ```
+
+3. Install:
+
+    ```bash
+    npm install @sahina/cvt-sdk
+    ```
+
+**Or from npmjs** (no authentication required):
 
 ```bash
-# Clone the repository (if you haven't already)
-git clone https://github.com/sahina/cvt.git
-
-# Install from local path
-cd your-project
-npm install ../cvt/sdks/node
+npm install @sahina/cvt-sdk
 ```
 
   </TabItem>
   <TabItem value="python" label="Python">
 
-**The Python SDK is not published to PyPI. Install from a local clone:**
+Install from a GitHub Release asset:
 
 ```bash
-# Clone the repository (if you haven't already)
-git clone https://github.com/sahina/cvt.git
-
-# Install from local path
-pip install ./cvt/sdks/python
+pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 
 # Or with uv
-uv pip install ./cvt/sdks/python
+uv add "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 ```
+
+Replace `v0.1.0` in the URL and `0.1.0` in the filename with the desired version. Available versions can be found on the [Releases](https://github.com/sahina/cvt/releases) page.
 
   </TabItem>
   <TabItem value="go" label="Go">
@@ -96,39 +105,43 @@ go get github.com/sahina/cvt/sdks/go
   </TabItem>
   <TabItem value="java" label="Java">
 
-**The Java SDK is not published to Maven Central. Build and publish to your local Maven repository:**
+**GitHub Packages (recommended):**
 
-```bash
-# Clone the repository (if you haven't already)
-git clone https://github.com/sahina/cvt.git
-cd cvt/sdks/java
+1. Create a GitHub [Personal Access Token](https://github.com/settings/tokens) with `read:packages` scope
+2. Add the repository and credentials to your `~/.m2/settings.xml`:
 
-# Build and install to local Maven repository
-mvn install
-```
+    ```xml
+    <settings>
+      <servers>
+        <server>
+          <id>github-cvt</id>
+          <username>YOUR_GITHUB_USERNAME</username>
+          <password>YOUR_GITHUB_PAT</password>
+        </server>
+      </servers>
+    </settings>
+    ```
 
-Then add to your `build.gradle`:
+3. Add the GitHub Packages repository and dependency to your `pom.xml`:
 
-```gradle
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
+    ```xml
+    <repositories>
+        <repository>
+            <id>github-cvt</id>
+            <url>https://maven.pkg.github.com/sahina/cvt</url>
+        </repository>
+    </repositories>
 
-dependencies {
-    implementation 'com.cvt:cvt-sdk:0.1.0'
-}
-```
+    <dependencies>
+        <dependency>
+            <groupId>com.cvt</groupId>
+            <artifactId>cvt-sdk</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+    ```
 
-Or for Maven, add to your `pom.xml`:
-
-```xml
-<dependency>
-    <groupId>com.cvt</groupId>
-    <artifactId>cvt-sdk</artifactId>
-    <version>0.1.0</version>
-</dependency>
-```
+Replace `0.1.0` with the desired version. Available versions can be found on the project's [GitHub Packages](https://github.com/sahina/cvt/packages) page.
 
   </TabItem>
 </Tabs>

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -44,20 +44,17 @@ make run-server
 
 ### 2. Install an SDK
 
-Node.js and Python SDKs are installed from a local clone (not yet published to package registries). The Go SDK can be installed directly from GitHub:
-
 ```bash
-# Clone the repository into your project directory
-git clone https://github.com/sahina/cvt.git
+# Node.js (from npmjs — no auth required)
+npm install @sahina/cvt-sdk
 
-# Node.js (from local clone)
-npm install ./cvt/sdks/node
+# Python (from GitHub Releases)
+pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 
-# Python (from local clone)
-pip install ./cvt/sdks/python
-
-# Go (from GitHub - no local clone needed)
+# Go
 go get github.com/sahina/cvt/sdks/go
+
+# Java (from GitHub Packages — requires PAT setup, see Installation guide)
 ```
 
 See [Installation](./getting-started/installation.mdx) for detailed instructions.

--- a/docs/reference/sdk/index.mdx
+++ b/docs/reference/sdk/index.mdx
@@ -18,8 +18,8 @@ This section provides documentation for CVT's language-specific SDKs. Each SDK o
 For information about SDK design patterns, adapter architecture, and how SDKs maintain cross-language consistency, see [SDK Architecture](../architecture/sdk-architecture.md).
 :::
 
-:::note Local Installation Only
-CVT SDKs are **not published** to public package registries (npm, PyPI, Maven Central, etc.). Install SDKs directly from your local CVT clone or from your organization's internal artifact repository.
+:::tip Published SDKs
+CVT SDKs are published to package registries: Node.js to [GitHub Packages](https://github.com/sahina/cvt/packages) and [npmjs](https://www.npmjs.com/package/@sahina/cvt-sdk), Java to [GitHub Packages](https://github.com/sahina/cvt/packages), Python to [GitHub Releases](https://github.com/sahina/cvt/releases), and Go via `go get`.
 :::
 
 ## Available SDKs
@@ -33,51 +33,39 @@ CVT SDKs are **not published** to public package registries (npm, PyPI, Maven Ce
 
 ## Installation
 
-Install SDKs from your local CVT clone:
-
 <Tabs groupId="sdk-language">
 <TabItem value="nodejs" label="Node.js">
 
 ```bash
-# Using npm
-npm install ./path/to/cvt/sdks/node
+# From npmjs (no auth required)
+npm install @sahina/cvt-sdk
 
-# Using pnpm
-pnpm add ./path/to/cvt/sdks/node
+# Or from GitHub Packages (recommended — single PAT for all SDKs)
+# See Node.js SDK docs for .npmrc setup
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```bash
-# Using pip
-pip install ./path/to/cvt/sdks/python
-
-# Using uv
-uv pip install ./path/to/cvt/sdks/python
+# From GitHub Releases
+pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 ```
 
 </TabItem>
 <TabItem value="go" label="Go">
 
 ```bash
-# Add to go.mod with replace directive
-go mod edit -replace github.com/sahina/cvt/sdks/go=./path/to/cvt/sdks/go
-
-# Or copy the SDK into your project
-cp -r ./path/to/cvt/sdks/go ./vendor/cvt
+go get github.com/sahina/cvt/sdks/go
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```bash
-# Build and install to local Maven repository
-cd ./path/to/cvt/sdks/java
-mvn install
-
-# Then add to your build.gradle or pom.xml
-# implementation 'com.cvt:cvt-sdk:1.0.0'
+# From GitHub Packages (requires PAT — see Java SDK docs for setup)
+# Maven: add github-cvt repository + dependency to pom.xml
+# Gradle: add maven repository + dependency to build.gradle
 ```
 
 </TabItem>

--- a/docs/reference/sdk/java.md
+++ b/docs/reference/sdk/java.md
@@ -17,31 +17,62 @@ For information about SDK design patterns, adapter architecture, and cross-langu
 
 ## Installation
 
-```bash
-# From local clone (SDK not published to Maven Central)
-cd ./path/to/cvt/sdks/java
-mvn install
-```
+Install from GitHub Packages (requires a GitHub PAT with `read:packages` scope):
 
-Then add to your build file:
+1. Add credentials to `~/.m2/settings.xml`:
 
-### Gradle
+    ```xml
+    <settings>
+      <servers>
+        <server>
+          <id>github-cvt</id>
+          <username>YOUR_GITHUB_USERNAME</username>
+          <password>YOUR_GITHUB_PAT</password>
+        </server>
+      </servers>
+    </settings>
+    ```
 
-```gradle
-dependencies {
-    implementation 'com.cvt:cvt-sdk:1.0.0'
-}
-```
+2. Add the repository and dependency to your build file:
 
 ### Maven
 
 ```xml
-<dependency>
-    <groupId>com.cvt</groupId>
-    <artifactId>cvt-sdk</artifactId>
-    <version>1.0.0</version>
-</dependency>
+<repositories>
+    <repository>
+        <id>github-cvt</id>
+        <url>https://maven.pkg.github.com/sahina/cvt</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>com.cvt</groupId>
+        <artifactId>cvt-sdk</artifactId>
+        <version>0.1.0</version>
+    </dependency>
+</dependencies>
 ```
+
+### Gradle
+
+```gradle
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/sahina/cvt")
+        credentials {
+            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_PAT")
+        }
+    }
+}
+
+dependencies {
+    implementation 'com.cvt:cvt-sdk:0.1.0'
+}
+```
+
+Replace `0.1.0` with the desired version. Available versions can be found on the project's [GitHub Packages](https://github.com/sahina/cvt/packages) page.
 
 ## Quick Start
 

--- a/docs/reference/sdk/nodejs.md
+++ b/docs/reference/sdk/nodejs.md
@@ -17,12 +17,26 @@ For information about SDK design patterns, adapter architecture, and cross-langu
 
 ## Installation
 
-```bash
-# From local clone (SDK not published to npm)
-npm install ./cvt/sdks/node
+**GitHub Packages (recommended)** — single PAT covers both Node.js and Java SDKs:
 
-# Or with pnpm
-pnpm add ./cvt/sdks/node
+1. Create a GitHub [Personal Access Token](https://github.com/settings/tokens) with `read:packages` scope
+2. Add to `.npmrc`:
+
+    ```text
+    @sahina:registry=https://npm.pkg.github.com
+    //npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+    ```
+
+3. Install:
+
+    ```bash
+    npm install @sahina/cvt-sdk
+    ```
+
+**Or from npmjs** (no authentication required):
+
+```bash
+npm install @sahina/cvt-sdk
 ```
 
 ## Quick Start

--- a/docs/reference/sdk/python.md
+++ b/docs/reference/sdk/python.md
@@ -17,13 +17,16 @@ For information about SDK design patterns, adapter architecture, and cross-langu
 
 ## Installation
 
+Install from a GitHub Release asset:
+
 ```bash
-# From local clone (SDK not yet published to PyPI)
-pip install ./cvt/sdks/python
+pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 
 # Or with uv
-uv pip install ./cvt/sdks/python
+uv add "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 ```
+
+Replace `v0.1.0` in the URL and `0.1.0` in the filename with the desired version. Available versions can be found on the [Releases](https://github.com/sahina/cvt/releases) page.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Remove all "not published" / "internal use only" notes from docs
- Update installation instructions across 6 doc files to match actual distribution:
  - **Node.js**: GitHub Packages (recommended) and npmjs
  - **Java**: GitHub Packages with Maven/Gradle PAT setup
  - **Python**: GitHub Release asset URLs
  - **Go**: `go get` (unchanged)

## Files changed

- `docs/intro.md` — updated quick start SDK install section
- `docs/getting-started/installation.mdx` — full rewrite of SDK installation tabs
- `docs/reference/sdk/index.mdx` — replaced "not published" note, updated install tabs
- `docs/reference/sdk/nodejs.md` — GitHub Packages + npmjs instructions
- `docs/reference/sdk/python.md` — GitHub Releases install instructions
- `docs/reference/sdk/java.md` — GitHub Packages Maven/Gradle instructions

## Test plan

- [ ] Build docs site locally (`cd docs-site && npm run build`) to verify no broken markup
- [ ] Review rendered tabs in each updated page