### PR TITLE
docs: clarify Gradle credentials and Python version replacement

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -161,6 +161,8 @@ go get github.com/sahina/cvt/sdks/go
     }
     ```
 
+Provide your credentials by setting `gpr.user` and `gpr.key` in your `~/.gradle/gradle.properties` file, or by exporting `GITHUB_USERNAME` and `GITHUB_PAT` as environment variables.
+
 Replace `0.1.0` with the desired version. Available versions can be found on the project's [GitHub Packages](https://github.com/sahina/cvt/packages) page.
 
   </TabItem>

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -48,7 +48,7 @@ make run-server
 # Node.js (from npmjs — no auth required)
 npm install @sahina/cvt-sdk
 
-# Python (from GitHub Releases — replace v0.1.0 with latest version)
+# Python (from GitHub Releases — replace v0.1.0 in the URL and 0.1.0 in the filename with latest version)
 pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 
 # Go

--- a/docs/reference/sdk/index.mdx
+++ b/docs/reference/sdk/index.mdx
@@ -48,7 +48,7 @@ npm install @sahina/cvt-sdk
 <TabItem value="python" label="Python">
 
 ```bash
-# From GitHub Releases (replace v0.1.0 with latest version)
+# From GitHub Releases (replace v0.1.0 in the URL and 0.1.0 in the filename with latest version)
 pip install "cvt-sdk @ https://github.com/sahina/cvt/releases/download/v0.1.0/cvt_sdk-0.1.0-py3-none-any.whl"
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #47, addressing review feedback:

- Add guidance on setting Gradle credentials via `gradle.properties` or env vars
- Clarify that Python install URL requires replacing version in both the tag and filename