### PR TITLE
fix: add OpenAPI schema generator to docs sidebar navigation

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
         'ai-helper/context-templates',
         'ai-helper/common-mistakes',
         'ai-helper/advanced-patterns',
+        'ai-helper/openapi-schema-generator',
       ],
     },
     {


### PR DESCRIPTION
The new ai-helper/openapi-schema-generator page was missing from the sidebars.ts config, so it didn't appear in the left navigation.

https://claude.ai/code/session_017zBJDVtXvuhBCwyGkAm62j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added documentation page for the OpenAPI schema generator to the navigation menu, making it easier to access information about this tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->