### PR TITLE
fix: update Node.js SDK for npmjs package page

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,33 +1,18 @@
-# Contract Validator Toolkit (CVT) - Node.js SDK
+# @sahina/cvt-sdk
 
-The **CVT Node.js SDK** allows you to validate HTTP interactions (requests and responses) against OpenAPI schemas using the CVT gRPC service.
+The Node.js SDK for **Contract Validator Toolkit (CVT)** — a consumer-driven contract validation platform for OpenAPI v2/v3 specifications.
 
-> **Status**: Fully Implemented
+CVT validates HTTP request/response interactions against registered OpenAPI schemas using a gRPC service. This SDK provides:
+
+- Schema registration and validation against OpenAPI v2/v3 specs
+- HTTP adapters (Axios, Fetch) for automatic traffic validation
+- Server-side middleware (Express, Fastify) for producer validation
+- Breaking change detection between schema versions
+- Consumer registry and deployment safety checks (can-i-deploy)
+
+For full documentation, visit the [CVT Documentation](https://sahina.github.io/cvt/).
 
 ## Installation
-
-### GitHub Packages (recommended)
-
-Using GitHub Packages lets you install all CVT SDKs (Node.js and Java) with a single PAT:
-
-1. Create a GitHub [Personal Access Token](https://github.com/settings/tokens) with `read:packages` scope
-
-2. Add a `.npmrc` file to your project root (or `~/.npmrc` for global config):
-
-    ```text
-    @sahina:registry=https://npm.pkg.github.com
-    //npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
-    ```
-
-3. Install:
-
-    ```bash
-    npm install @sahina/cvt-sdk
-    ```
-
-### npmjs
-
-Also available on npmjs (no authentication required):
 
 ```bash
 npm install @sahina/cvt-sdk
@@ -153,7 +138,7 @@ const response = await api.post("/pets", { name: "Fluffy" });
 
 Validate incoming requests and outgoing responses against your OpenAPI contract on the server side.
 
-> **Full documentation:** See [Validation Modes](../../docs/guides/validation-modes.mdx) for detailed behavior, rollout strategy, and metrics information.
+> **Full documentation:** See [Validation Modes](https://sahina.github.io/cvt/docs/guides/validation-modes) for detailed behavior, rollout strategy, and metrics information.
 
 ### Validation Modes
 
@@ -163,7 +148,7 @@ Validate incoming requests and outgoing responses against your OpenAPI contract 
 | `"warn"`   | Log, continue     | Log, continue      | Gradual rollout        |
 | `"shadow"` | Metrics only      | Metrics only       | Initial deployment     |
 
-**Recommended rollout:** `shadow` → `warn` → `strict`. See [Recommended Rollout Strategy](../../docs/guides/validation-modes.mdx#recommended-rollout-strategy).
+**Recommended rollout:** `shadow` → `warn` → `strict`. See [Recommended Rollout Strategy](https://sahina.github.io/cvt/docs/guides/validation-modes#recommended-rollout-strategy).
 
 ### Express Middleware
 
@@ -253,7 +238,7 @@ if (!result.compatible) {
 | `FIELD_TYPE_CHANGED`   | A field's type was changed            |
 | `ENUM_VALUE_REMOVED`   | An allowed enum value was removed     |
 
-See `examples/breaking-changes.ts` for a complete example.
+See [`examples/breaking-changes.ts`](https://github.com/sahina/cvt/tree/main/sdks/node/examples/breaking-changes.ts) for a complete example.
 
 ## Producer Testing
 
@@ -332,7 +317,7 @@ if (!result.safeToDeploy) {
 }
 ```
 
-See [Producer Testing Guide](../../docs/guides/producer-testing.mdx) for complete documentation.
+See [Producer Testing Guide](https://sahina.github.io/cvt/docs/guides/producer-testing) for complete documentation.
 
 ## Security Configuration
 

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -2,11 +2,9 @@
   "name": "@sahina/cvt-sdk",
   "version": "0.1.0",
   "description": "Contract Validator Toolkit SDK",
+  "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "files": [
     "dist/src/**",
     "proto/**",


### PR DESCRIPTION
## Summary

- Add project context and feature summary to README for npmjs visitors
- Simplify installation to show `npm install` only (remove GitHub Packages instructions)
- Replace relative doc links (`../../docs/...`) with absolute URLs to docs site and GitHub
- Remove "Status: Fully Implemented" badge
- Add `"license": "MIT"` to package.json so npmjs displays the license
- Remove `publishConfig` block (workflow's `setup-node` already controls the registry for each publish step)

## Test plan

- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` confirms README.md is included
- [x] No relative (`../../`) links remain in README
- [ ] After next release, verify npmjs page shows MIT license and updated README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README with updated project description emphasizing CVT as a consumer-driven contract validation platform.
  * Documentation references now point to external online resources for improved accessibility.

* **Chores**
  * Added MIT license declaration to package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->