### PR TITLE
docs: fix CLI command examples in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,11 +210,11 @@ cvt compare --old ./local.json --new https://api.example.com/openapi.json  # Mix
 **generate** - Generate test fixtures from schemas (file paths or URLs):
 
 ```bash
-cvt generate --schema ./openapi.json --endpoint "GET /users/{id}"
-cvt generate --schema ./openapi.json --endpoint "POST /users" --output-type request
+cvt generate --schema ./openapi.json --method GET --path /users/{id}
+cvt generate --schema ./openapi.json --method POST --path /users --output-type request
 cvt generate --schema ./openapi.json --list  # List all endpoints
 cvt generate --schema https://petstore3.swagger.io/api/v3/openapi.json --list  # List from URL
-cvt generate --schema ./openapi.json --endpoint "GET /users" --use-examples  # Use schema examples
+cvt generate --schema ./openapi.json --method GET --path /users --use-examples  # Use schema examples
 ```
 
 **can-i-deploy** - Check deployment safety against registered consumers (requires server):


### PR DESCRIPTION
## Summary
- Fix `can-i-deploy` examples to use schema ID with `--version`/`--env` flags instead of file paths
- Fix `generate` examples to use `--method`/`--path` flags instead of non-existent `--endpoint` flag
- Remove undocumented `--api-key-auth` flag from `serve` examples (declared but never wired up)

## Test plan
- [x] Verified all fixes against actual CLI flag definitions in `cmd/cvt/`
- [x] Reviewed remaining CLAUDE.md sections — no other gaps found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and clarified parameter naming in command examples for `generate` and `can-i-deploy` with improved usage illustrations
  * Expanded `wait` command documentation with additional options including configurable timeouts, intervals, quiet mode, and JSON output formats
  * Removed deprecated flag examples from legacy command references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->