### PR TITLE
chore: speed up Maven Central publish

### DIFF
--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -318,7 +318,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary
- Change `waitUntil` from `published` to `validated` in the central-publishing-maven-plugin config
- Reduces CI wait from ~25min to ~5-10min
- Publishing continues asynchronously after validation passes

## Context
The `published` setting blocks until artifacts are fully synced to Maven Central CDN, which takes 20-30 minutes. `validated` still catches validation errors (bad POM, missing GPG sig, etc.) but returns once validation passes, letting publishing complete in the background.