### PR TITLE
chore: add make check-release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: metrics grafana prometheus observability-status observability-logs
 .PHONY: lint lint-go lint-node lint-python lint-java ci check-coverage ci-full
 .PHONY: docs-dev docs-build docs-serve docs-deploy docs-install
-.PHONY: tag tag-push release prerelease _check_tag _check_tag_prerelease
+.PHONY: tag tag-push release prerelease _check_tag _check_tag_prerelease check-release
 
 # Default target
 all: build
@@ -707,3 +707,12 @@ delete-release: _check_tag
 	git push origin :refs/tags/v$(TAG) 2>/dev/null && echo "   ✅ Version tag deleted" || echo "   ⏭️  No remote version tag found"; \
 	echo ""; \
 	echo "✅ Cleanup complete for v$(TAG)"
+
+# Check the current release version based on git tags
+check-release:
+	@TAG=$$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); \
+	if [ -z "$$TAG" ]; then \
+		echo "No releases have been made yet."; \
+	else \
+		echo "Current release: $$TAG"; \
+	fi

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -110,12 +110,12 @@ make release TAG=1.0.0
 
 The release workflow automatically publishes all SDKs to their public registries:
 
-| SDK | Registry | Mechanism |
-|-----|----------|-----------|
-| Node.js | [npmjs](https://www.npmjs.com/package/@sahina/cvt-sdk) | `npm publish` with `NPM_TOKEN` secret |
-| Java | [Maven Central](https://central.sonatype.com/artifact/io.github.sahina/cvt-sdk) | `mvn deploy -Prelease` with GPG signing |
-| Python | [PyPI](https://pypi.org/project/cvt-sdk/) | Trusted publisher (OIDC, no token needed) |
-| Go | `go get` | Git tag `sdks/go/vX.Y.Z` pushed to origin |
+| SDK     | Registry                                                                        | Mechanism                                 |
+| ------- | ------------------------------------------------------------------------------- | ----------------------------------------- |
+| Node.js | [npmjs](https://www.npmjs.com/package/@sahina/cvt-sdk)                          | `npm publish` with `NPM_TOKEN` secret     |
+| Java    | [Maven Central](https://central.sonatype.com/artifact/io.github.sahina/cvt-sdk) | `mvn deploy -Prelease` with GPG signing   |
+| Python  | [PyPI](https://pypi.org/project/cvt-sdk/)                                       | Trusted publisher (OIDC, no token needed) |
+| Go      | `go get`                                                                        | Git tag `sdks/go/vX.Y.Z` pushed to origin |
 
 All SDK jobs run in parallel after `validate`, so they don't block each other.
 
@@ -157,6 +157,7 @@ All images are built for multiple platforms:
 | `make tag-push TAG=x.y.z`          | Create and push a git tag         |
 | `make release TAG=x.y.z`           | Alias for `tag-push`              |
 | `make prerelease TAG=x.y.z-suffix` | Create and push a pre-release tag |
+| `make check-release`               | Show the current release version  |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add `make check-release` Makefile target that prints the current release version based on git tags
- Document the new command in `docs/development/releasing.md`

## Test plan
- [ ] Run `make check-release` and verify it prints the latest `v*` tag
- [ ] Verify output when no tags exist shows fallback message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to view the current release version or confirm when no releases exist.

* **Documentation**
  * Updated release documentation to include information about the new command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->