### PR TITLE
fix: checkout main branch for agent skills version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,9 +102,10 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout main branch
         uses: actions/checkout@v6
         with:
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update skills VERSION file


### PR DESCRIPTION
The release workflow's update-agent-skills job checks out the tag by default, but it needs to modify main's files. This caused a push rejection because the tag's .github/workflows/ diff triggered a workflows permission error. Fix: explicitly checkout main for this job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to ensure builds target the correct branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->