### PR TITLE
docs: clarify producer ownership of schema registration

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -5,8 +5,8 @@ sidebar_position: 2
 description: Your first contract test in 5 minutes
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Quick Start
 
@@ -18,6 +18,7 @@ This guide walks you through your first contract test in under 5 minutes.
 - An OpenAPI schema to test against (we'll use the included Petstore schema)
 
 You can either:
+
 - Save the [Petstore OpenAPI schema](https://petstore3.swagger.io/api/v3/openapi.json) as `./openapi.json` in your project directory, OR
 - Use the URL directly: `https://petstore3.swagger.io/api/v3/openapi.json`
 
@@ -55,48 +56,48 @@ In a team environment, the **producer** (API owner) registers their OpenAPI sche
 Create a test file `contract.test.ts`:
 
 ```typescript
-import { ContractValidator } from '@sahina/cvt-sdk';
-import * as path from 'path';
+import { ContractValidator } from "@sahina/cvt-sdk";
+import * as path from "path";
 
-describe('Petstore API Contract', () => {
+describe("Petstore API Contract", () => {
   let validator: ContractValidator;
 
   beforeAll(async () => {
-    validator = new ContractValidator('localhost:9550');
+    validator = new ContractValidator("localhost:9550");
 
     // Register the Petstore schema from file
-    const schemaPath = path.resolve(__dirname, './openapi.json');
-    await validator.registerSchema('petstore', schemaPath);
+    const schemaPath = path.resolve(__dirname, "./openapi.json");
+    await validator.registerSchema("petstore", schemaPath);
     // Or register from URL:
     // await validator.registerSchema('petstore', 'https://petstore3.swagger.io/api/v3/openapi.json');
   });
 
   afterAll(() => validator.close());
 
-  it('validates a correct pet response', async () => {
+  it("validates a correct pet response", async () => {
     const result = await validator.validate(
-      { method: 'GET', path: '/pet/123' },
+      { method: "GET", path: "/pet/123" },
       {
         statusCode: 200,
         body: {
           id: 123,
-          name: 'doggie',
-          photoUrls: ['https://example.com/photo.jpg'],
-          status: 'available'
-        }
-      }
+          name: "doggie",
+          photoUrls: ["https://example.com/photo.jpg"],
+          status: "available",
+        },
+      },
     );
 
     expect(result.valid).toBe(true);
   });
 
-  it('catches invalid responses', async () => {
+  it("catches invalid responses", async () => {
     const result = await validator.validate(
-      { method: 'GET', path: '/pet/123' },
+      { method: "GET", path: "/pet/123" },
       {
         statusCode: 200,
-        body: { id: 123 }  // missing required 'name' and 'photoUrls' fields
-      }
+        body: { id: 123 }, // missing required 'name' and 'photoUrls' fields
+      },
     );
 
     expect(result.valid).toBe(false);
@@ -359,7 +360,10 @@ Now that you've validated your first interaction, explore:
 
 ```typescript
 // Register schema directly from URL
-await validator.registerSchema('petstore', 'https://petstore3.swagger.io/api/v3/openapi.json');
+await validator.registerSchema(
+  "petstore",
+  "https://petstore3.swagger.io/api/v3/openapi.json",
+);
 ```
 
 ### Using HTTP Adapters
@@ -367,14 +371,18 @@ await validator.registerSchema('petstore', 'https://petstore3.swagger.io/api/v3/
 Automatically validate all HTTP traffic:
 
 ```typescript
-import axios from 'axios';
-import { createAxiosAdapter } from '@sahina/cvt-sdk/adapters';
+import axios from "axios";
+import { createAxiosAdapter } from "@sahina/cvt-sdk/adapters";
 
-const api = axios.create({ baseURL: 'http://api.example.com' });
-const adapter = createAxiosAdapter({ axios: api, validator, autoValidate: true });
+const api = axios.create({ baseURL: "http://api.example.com" });
+const adapter = createAxiosAdapter({
+  axios: api,
+  validator,
+  autoValidate: true,
+});
 
 // All requests/responses are now validated automatically
-const pet = await api.get('/pet/123');
+const pet = await api.get("/pet/123");
 
 // Check validation results
 const interactions = adapter.getInteractions();
@@ -387,13 +395,17 @@ Enable deployment safety checks:
 
 ```typescript
 await validator.registerConsumer({
-  consumerId: 'my-service',
-  consumerVersion: '1.0.0',
-  schemaId: 'petstore',
-  schemaVersion: '1.0.0',
-  environment: 'dev',
+  consumerId: "my-service",
+  consumerVersion: "1.0.0",
+  schemaId: "petstore",
+  schemaVersion: "1.0.0",
+  environment: "dev",
   usedEndpoints: [
-    { method: 'GET', path: '/pet/{petId}', usedFields: ['id', 'name', 'status'] }
-  ]
+    {
+      method: "GET",
+      path: "/pet/{petId}",
+      usedFields: ["id", "name", "status"],
+    },
+  ],
 });
 ```

--- a/docs/guides/ci-cd-integration.mdx
+++ b/docs/guides/ci-cd-integration.mdx
@@ -56,12 +56,12 @@ CVT works best when each team has a clear role. The **producer owns the schema**
 └──────────────────────────────┘
 ```
 
-| Step | Who | What | When |
-| ---- | --- | ---- | ---- |
-| Register schema | **Producer** | Publishes OpenAPI spec to CVT | On merge to main |
-| Validate interactions | **Consumer** | Tests requests/responses against schema | On every CI run |
-| Register consumer | **Consumer** | Records which endpoints are used | After tests pass on main |
-| can-i-deploy | **Producer** | Checks if schema changes break consumers | Before deploying |
+| Step                  | Who          | What                                     | When                     |
+| --------------------- | ------------ | ---------------------------------------- | ------------------------ |
+| Register schema       | **Producer** | Publishes OpenAPI spec to CVT            | On merge to main         |
+| Validate interactions | **Consumer** | Tests requests/responses against schema  | On every CI run          |
+| Register consumer     | **Consumer** | Records which endpoints are used         | After tests pass on main |
+| can-i-deploy          | **Producer** | Checks if schema changes break consumers | Before deploying         |
 
 :::caution Schema Registration Ownership
 The **producer** should register their schema in CVT — not the consumer. If consumers register schemas independently, you risk stale or inconsistent contracts. In local development, consumers may register schemas for convenience, but in CI/CD the producer's pipeline should be the single source of truth.
@@ -117,7 +117,7 @@ The published CVT server image is available at `ghcr.io/sahina/cvt:latest`. You 
 1. Build your own image: `docker build -t cvt .`
 2. Use `make up` to run CVT locally
 3. Host CVT as a shared service in your infrastructure
-:::
+   :::
 
 ### Producer Deployment Safety
 

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -5,8 +5,8 @@ sidebar_position: 1
 description: Complete guide to testing your API consumers with CVT
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Consumer Testing Guide
 
@@ -16,12 +16,17 @@ This guide covers how to test your service's API integrations using CVT. Consume
 The examples in this guide use the Petstore schema from `sdks/shared/openapi.json`. Copy it to your project as `openapi.json` or adjust the paths to reference it directly.
 
 All `registerSchema` methods accept both **file paths** and **URLs**:
+
 ```typescript
 // From file
 await validator.registerSchema("petstore", "./openapi.json");
 // From URL
-await validator.registerSchema("petstore", "https://petstore3.swagger.io/api/v3/openapi.json");
+await validator.registerSchema(
+  "petstore",
+  "https://petstore3.swagger.io/api/v3/openapi.json",
+);
 ```
+
 :::
 
 ## Overview
@@ -43,8 +48,8 @@ When your service depends on external APIs, you need confidence that:
          │ Validate & Register Consumer         │ Register Schema (owns it)
          ▼                                      ▼
 ┌───────────────────────────────────────────────────────────┐
-│                    CVT Server (shared)                     │
-│              Producer's Schema = Source of Truth           │
+│                    CVT Server (shared)                    │
+│              Producer's Schema = Source of Truth          │
 └───────────────────────────────────────────────────────────┘
 ```
 
@@ -92,7 +97,10 @@ describe("Petstore Contract", () => {
   it("GET /pet/{petId} returns valid response", async () => {
     const result = await validator.validate(
       { method: "GET", path: "/pet/123" },
-      { statusCode: 200, body: { id: 123, name: "Fluffy", status: "available", photoUrls: [] } },
+      {
+        statusCode: 200,
+        body: { id: 123, name: "Fluffy", status: "available", photoUrls: [] },
+      },
     );
     expect(result.valid).toBe(true);
   });
@@ -217,13 +225,13 @@ CVT supports multiple ways to validate your API interactions.
 
 ### Choosing an Approach
 
-| Scenario                              | Recommended Approach |
-| ------------------------------------- | -------------------- |
-| CI/CD pipeline without services       | Mock Client          |
-| Adding validation to existing tests   | HTTP Adapter         |
-| Testing specific error responses      | Manual Validation    |
-| Unit testing consumer logic           | Mock Client          |
-| Integration testing with real API     | HTTP Adapter         |
+| Scenario                            | Recommended Approach |
+| ----------------------------------- | -------------------- |
+| CI/CD pipeline without services     | Mock Client          |
+| Adding validation to existing tests | HTTP Adapter         |
+| Testing specific error responses    | Manual Validation    |
+| Unit testing consumer logic         | Mock Client          |
+| Integration testing with real API   | HTTP Adapter         |
 
 ### Approach 1: Manual Validation
 

--- a/docs/guides/producer-testing.mdx
+++ b/docs/guides/producer-testing.mdx
@@ -16,12 +16,17 @@ This guide covers how to use CVT for producer-side contract testing. Producer te
 The examples in this guide use the Petstore schema from `sdks/shared/openapi.json`. Copy it to your project as `openapi.json` or adjust the paths to reference it directly.
 
 All `registerSchema` methods accept both **file paths** and **URLs**:
+
 ```typescript
 // From file
 await validator.registerSchema("petstore", "./openapi.json");
 // From URL
-await validator.registerSchema("petstore", "https://petstore3.swagger.io/api/v3/openapi.json");
+await validator.registerSchema(
+  "petstore",
+  "https://petstore3.swagger.io/api/v3/openapi.json",
+);
 ```
+
 :::
 
 ## Overview
@@ -734,7 +739,11 @@ cvt register-schema my-api ./openapi.json \
 ```typescript
 // In a CI/CD script or test setup
 const validator = new ContractValidator(process.env.CVT_SERVER_URL);
-await validator.registerSchemaWithVersion("my-api", "./openapi.json", process.env.API_VERSION);
+await validator.registerSchemaWithVersion(
+  "my-api",
+  "./openapi.json",
+  process.env.API_VERSION,
+);
 ```
 
 </TabItem>
@@ -750,12 +759,12 @@ err := validator.RegisterSchemaWithVersion(ctx, "my-api", "./openapi.json", os.G
 
 ### Why the producer must register
 
-| If the producer registers...           | If the consumer registers...             |
-| -------------------------------------- | ---------------------------------------- |
-| Schema always matches the real API     | Schema may be stale or incorrect         |
-| Single source of truth                 | Multiple consumers may register different versions |
-| `can-i-deploy` checks are meaningful   | Breaking change detection is unreliable  |
-| Clear ownership and accountability     | Unclear who maintains the contract       |
+| If the producer registers...         | If the consumer registers...                       |
+| ------------------------------------ | -------------------------------------------------- |
+| Schema always matches the real API   | Schema may be stale or incorrect                   |
+| Single source of truth               | Multiple consumers may register different versions |
+| `can-i-deploy` checks are meaningful | Breaking change detection is unreliable            |
+| Clear ownership and accountability   | Unclear who maintains the contract                 |
 
 ---
 


### PR DESCRIPTION
Address feedback that the documentation was consumer-centric and unclear
about who should register schemas. Updates across four docs:

- Consumer Testing Guide: adds callout that producer owns the schema;
  consumer registerSchema calls are a convenience for local dev
- Producer Testing Guide: adds tip about schema ownership and a new
  "Schema Registration in CI/CD" section with examples and rationale
- CI/CD Integration Guide: adds "Recommended Workflow" section with
  clear diagram showing producer registers, consumer validates
- Quick Start: adds note distinguishing the simplified getting-started
  flow from the recommended team workflow

https://claude.ai/code/session_0136ckxx6tvGDcDNbotn2Brw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified producer vs consumer responsibilities and established producer-owned schema as the single source of truth in the shared CVT server model
  * Added a Recommended CI/CD workflow with sequencing, ownership rules, and a can-i-deploy check
  * Added informational callouts and tables explaining registration vs validation and production registration practices
  * Standardized example formatting and updated diagrams and examples for clarity across guides
<!-- end of auto-generated comment: release notes by coderabbit.ai -->