### PR TITLE
docs: remove backward compatibility constraint from issue #83 pitch deck

### DIFF
--- a/docs/pitch/pitch-issue-83.html
+++ b/docs/pitch/pitch-issue-83.html
@@ -1157,10 +1157,10 @@
         </div>
       </div>
 
-      <p class="pivot-line reveal d5">New models add options &mdash; nothing that works today breaks.</p>
+      <p class="pivot-line reveal d5">New deployment models &mdash; the server evolves alongside them.</p>
 
       <p class="speaker-note reveal d6">
-        The key design principle: backward compatibility is absolute. No flags change meaning, no existing behavior changes. Teams opt in to new models explicitly.
+        The key design principle: new deployment topologies extend CVT's reach. The server model evolves as needed to support them. Teams choose the model that fits their workflow.
       </p>
     </div>
     <span class="slide-number">3 / 13</span>


### PR DESCRIPTION
## Summary
- Updated issue #83 to remove backward compatibility as a design constraint (CVT is a new project with no enterprise adaptors yet)
- Updated pitch deck (`docs/pitch/pitch-issue-83.html`) to align with the simplified issue — replaced "backward compatibility is absolute" language with "server evolves alongside new deployment topologies"

Relates to #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated messaging on deployment models to reflect how the platform evolves alongside new deployment topologies, allowing teams to select models matching their workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->