### PR TITLE
feat: add mock HTTP server command (cvt mock)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,16 @@ cvt generate --schema https://petstore3.swagger.io/api/v3/openapi.json --list  #
 cvt generate --schema ./openapi.json --method GET --path /users --use-examples  # Use schema examples
 ```
 
+**mock** - Start a mock HTTP server from OpenAPI schemas:
+
+```bash
+cvt mock --schema ./openapi.json                                # Basic mock server on port 8080
+cvt mock --schema a.json --schema b.json --port 3000            # Multiple schemas, custom port
+cvt mock --schema ./openapi.json --validate-requests --watch    # Validate requests + hot-reload
+cvt mock --schema https://petstore3.swagger.io/api/v3/openapi.json  # From URL
+cvt mock --schema ./openapi.json --latency 200                  # Simulate 200ms network delay
+```
+
 **can-i-deploy** - Check deployment safety against registered consumers (requires server):
 
 ```bash
@@ -278,6 +288,7 @@ The CLI uses the embedded library (`pkg/cvt/`) which can also be used directly i
 
 ## Port Configuration
 
+- **8080**: Mock HTTP server (default for `cvt mock`)
 - **9550**: gRPC server (both local and Docker)
 - **9551**: Prometheus metrics endpoint
 - **9091**: Prometheus UI (when running observability stack)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo "Test commands:"
 	@echo "  make test               - Run all tests with direct server (fast, no Docker)"
 	@echo "  make test-docker        - Run all tests with Docker + PostgreSQL (CI/CD)"
-	@echo "  make test-all           - Run all tests with Docker (same as 'make test-docker')"
+	@echo "  make test-all           - Run all tests with Docker + e2e"
 	@echo "  make test-with-observability - Run all tests, keep Docker Compose up"
 	@echo "  make test-server        - Run Go server unit tests only"
 	@echo "  make test-node-sdk      - Run Node.js SDK tests"
@@ -261,7 +261,7 @@ test-cache:
 	go test -v -run TestCache ./server/...
 	@echo "✅ Cache tests passed!"
 
-test-all: test-docker
+test-all: test-docker test-e2e
 
 test-with-observability:
 	@echo "🧪 Running all tests (server + all 4 SDKs) with observability stack..."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-cli install-cli test test-docker test-server test-cli test-node-sdk test-python-sdk test-go-sdk test-java-sdk test-integration test-cache test-all test-with-observability clean generate generate-python generate-go-sdk generate-java-sdk help
+.PHONY: all build build-cli install-cli test test-docker test-server test-cli test-e2e test-node-sdk test-python-sdk test-go-sdk test-java-sdk test-integration test-cache test-all test-with-observability clean generate generate-python generate-go-sdk generate-java-sdk help
 .PHONY: up down restart logs status
 .PHONY: install-health-probe health check-health watch-health
 .PHONY: run-server run-example
@@ -39,6 +39,7 @@ help:
 	@echo "  make test-coverage      - Run tests with coverage report (HTML + summary)"
 	@echo "  make test-integration   - Run Go server integration tests (requires Docker)"
 	@echo "  make test-cli           - Run CLI unit tests"
+	@echo "  make test-e2e           - Run CLI e2e tests (cvt mock)"
 	@echo "  make test-cache         - Run cache behavior tests"
 	@echo ""
 	@echo "Lint commands:"
@@ -249,6 +250,11 @@ test-integration:
 	@echo "🧪 Running integration tests (requires Docker)..."
 	go test -v -tags=integration ./server/...
 	@echo "✅ Integration tests passed!"
+
+test-e2e:
+	@echo "🧪 Running CLI e2e tests (cvt mock)..."
+	go test -v -tags=integration -timeout 120s ./cmd/cvt/...
+	@echo "✅ CLI e2e tests passed!"
 
 test-cache:
 	@echo "🧪 Running cache behavior tests..."

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Listen to an [AI-generated podcast](https://github.com/sahina/cvt/raw/main/asset
 - **Consumer Validation** - Validate outgoing API calls match the contract (client-side)
 - **Producer Validation** - Validate incoming requests match the contract (server-side middleware)
 - **Consumer Registry** - Track which consumers depend on which schemas
+- **Mock Server** - Generate a running HTTP mock server from any OpenAPI schema with `cvt mock`
 - **Deployment Safety** - `can-i-deploy` checks prevent breaking changes from reaching production
 - **High Performance** - gRPC-based server with schema caching (1000 schemas, 24h TTL)
 - **Multiple SDKs** - Node.js, Python, Go, and Java client libraries
@@ -182,6 +183,9 @@ cvt validate --schema ./openapi.json --request req.json --response resp.json
 
 # Detect breaking changes between schema versions
 cvt compare --old ./v1/openapi.json --new ./v2/openapi.json
+
+# Start a mock HTTP server from a schema
+cvt mock --schema ./openapi.json
 
 # Check deployment safety
 cvt can-i-deploy --schema my-api --version 2.0.0 --env prod

--- a/TODOS.md
+++ b/TODOS.md
@@ -114,12 +114,12 @@
 
 **What:** Cache gorillamux routers at schema registration time in `pkg/cvt/validator.go`, matching the server pattern in `validator_service.go:199-211`.
 
-**Why:** Currently creates a new router on every Validate call (O(P) per call where P = number of paths). Server caches at registration time. Accepted in eng review but not blocking Phase 1a since offline can-i-deploy doesn't use routers.
+**Why:** Currently creates a new router on every Validate call (O(P) per call where P = number of paths). Server caches at registration time. Accepted in eng review but not blocking Phase 1a since offline can-i-deploy doesn't use routers. Also impacts `cvt mock` performance: `findOperation()` in `generator.go` creates a new router per GenerateResponse call, meaning every mock request builds a router.
 
 **Effort:** S (human: ~2 hours) → with CC: S (~10 min)
 **Priority:** P3
 **Depends on:** None (can be done anytime)
-**Source:** Eng Review 2026-04-09
+**Source:** Eng Review 2026-04-09, CEO Review 2026-04-14 (mock server outside voice)
 
 ## P3: Ristretto cache cost model fix
 

--- a/cmd/cvt/examples/README.md
+++ b/cmd/cvt/examples/README.md
@@ -75,8 +75,8 @@ cvt mock \
   --schema ./sdks/shared/openapi.json \
   --port 3000
 
-# Then test it
-curl http://localhost:8080/users/1
+# Then test it (port 3000 from above)
+curl http://localhost:3000/users/1
 ```
 
 ## Expected Output

--- a/cmd/cvt/examples/README.md
+++ b/cmd/cvt/examples/README.md
@@ -58,6 +58,27 @@ cvt compare \
   --new ./sdks/shared/openapi-v2-breaking.json
 ```
 
+### Start a mock server
+
+```bash
+# Basic mock server on port 8080
+cvt mock --schema ./cmd/cvt/examples/schema.json
+
+# With request validation and hot-reload
+cvt mock \
+  --schema ./cmd/cvt/examples/schema.json \
+  --validate-requests --watch
+
+# Multiple schemas on a custom port
+cvt mock \
+  --schema ./cmd/cvt/examples/schema.json \
+  --schema ./sdks/shared/openapi.json \
+  --port 3000
+
+# Then test it
+curl http://localhost:8080/users/1
+```
+
 ## Expected Output
 
 ### Valid interaction

--- a/cmd/cvt/main.go
+++ b/cmd/cvt/main.go
@@ -44,6 +44,7 @@ Examples:
 	rootCmd.AddCommand(compareCmd())
 	rootCmd.AddCommand(serveCmd())
 	rootCmd.AddCommand(generateCmd())
+	rootCmd.AddCommand(mockCmd())
 	rootCmd.AddCommand(canIDeployCmd())
 	rootCmd.AddCommand(waitCmd())
 	rootCmd.AddCommand(registerSchemaCmd())

--- a/cmd/cvt/mock.go
+++ b/cmd/cvt/mock.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sahina/cvt/pkg/mock"
+	"github.com/spf13/cobra"
+)
+
+func mockCmd() *cobra.Command {
+	var (
+		schemas          []string
+		port             int
+		host             string
+		watch            bool
+		validateRequests bool
+		noExamples       bool
+		latency          int
+		quiet            bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "mock",
+		Short: "Start a mock HTTP server from OpenAPI schemas",
+		Long: `Start an HTTP server that generates mock responses from OpenAPI schemas.
+
+The mock server matches incoming HTTP requests to schema operations and
+returns generated responses. Supports multiple schemas, request validation,
+hot-reload, and CORS headers for frontend development.
+
+Examples:
+  # Basic mock server
+  cvt mock --schema ./openapi.json
+
+  # Custom port and multiple schemas
+  cvt mock --schema users.json --schema orders.json --port 3000
+
+  # With request validation and hot-reload
+  cvt mock --schema ./openapi.json --validate-requests --watch
+
+  # Mock from a URL
+  cvt mock --schema https://petstore3.swagger.io/api/v3/openapi.json
+
+  # Simulate network latency
+  cvt mock --schema ./openapi.json --latency 200`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(schemas) == 0 {
+				return fmt.Errorf("at least one --schema is required")
+			}
+
+			if port < 0 || port > 65535 {
+				return fmt.Errorf("invalid port: %d", port)
+			}
+
+			if latency < 0 {
+				return fmt.Errorf("--latency must be >= 0")
+			}
+
+			srv := mock.NewServer(mock.ServerConfig{
+				Host:             host,
+				Port:             port,
+				SchemaFiles:      schemas,
+				Watch:            watch,
+				ValidateRequests: validateRequests,
+				UseExamples:      !noExamples,
+				LatencyMs:        latency,
+				Quiet:            quiet,
+			})
+
+			return srv.Start()
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&schemas, "schema", nil, "OpenAPI schema file path or URL (can be specified multiple times)")
+	cmd.Flags().IntVarP(&port, "port", "p", 8080, "HTTP server port")
+	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "Bind address (default: localhost only)")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch schema files for changes and hot-reload")
+	cmd.Flags().BoolVar(&validateRequests, "validate-requests", false, "Validate incoming requests against the schema")
+	cmd.Flags().BoolVar(&noExamples, "no-examples", false, "Use generated values instead of schema examples")
+	cmd.Flags().IntVar(&latency, "latency", 0, "Artificial response delay in milliseconds")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress request logging")
+
+	return cmd
+}

--- a/cmd/cvt/mock_test.go
+++ b/cmd/cvt/mock_test.go
@@ -1,0 +1,560 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testBinary holds the path to the compiled cvt binary.
+var testBinary string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "cvt-mock-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	bin := filepath.Join(tmp, "cvt")
+	cmd := exec.Command("go", "build", "-o", bin, "./")
+	cmd.Dir = filepath.Join(repoRoot())
+	cmd.Dir = filepath.Join(cmd.Dir, "cmd", "cvt")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build cvt binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	testBinary = bin
+	os.Exit(m.Run())
+}
+
+// repoRoot returns the absolute path to the repository root.
+func repoRoot() string {
+	// cmd/cvt/mock_test.go -> repo root is ../../
+	dir, err := filepath.Abs("../../")
+	if err != nil {
+		panic(fmt.Sprintf("failed to resolve repo root: %v", err))
+	}
+	return dir
+}
+
+// schemaPath returns the absolute path to a test schema file.
+func schemaPath(relPath string) string {
+	return filepath.Join(repoRoot(), relPath)
+}
+
+// getFreePort returns an available TCP port on 127.0.0.1.
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// startMockServer starts cvt mock as a subprocess and waits for it to be ready.
+// It prepends --port <port> --quiet to the given args.
+// Returns the exec.Cmd, the port, and a cleanup function.
+func startMockServer(t *testing.T, binary string, args ...string) (*exec.Cmd, int, func()) {
+	t.Helper()
+
+	port := getFreePort(t)
+
+	fullArgs := []string{"mock", "--port", fmt.Sprintf("%d", port), "--quiet"}
+	fullArgs = append(fullArgs, args...)
+
+	cmd := exec.Command(binary, fullArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+
+	cleanup := func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	}
+	t.Cleanup(cleanup)
+
+	// Poll until the server is ready (max 5 seconds)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ready := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/")
+		if err == nil {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		cleanup()
+		t.Fatal("mock server did not start within 5 seconds")
+	}
+
+	return cmd, port, cleanup
+}
+
+// --- Test Cases ---
+
+func TestMockCLI_SingleSchema(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// GET /pets -> 200, JSON array
+	resp, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /pets: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var arr []interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&arr); err != nil {
+		t.Fatalf("GET /pets: expected JSON array, decode error: %v", err)
+	}
+
+	// GET /pets/42 -> 200, JSON object
+	resp2, err := http.Get(baseURL + "/pets/42")
+	if err != nil {
+		t.Fatalf("GET /pets/42 failed: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("GET /pets/42: expected 200, got %d: %s", resp2.StatusCode, body)
+	}
+	var obj map[string]interface{}
+	if err := json.NewDecoder(resp2.Body).Decode(&obj); err != nil {
+		t.Fatalf("GET /pets/42: expected JSON object, decode error: %v", err)
+	}
+
+	// GET /unknown -> 404
+	resp3, err := http.Get(baseURL + "/unknown")
+	if err != nil {
+		t.Fatalf("GET /unknown failed: %v", err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Errorf("GET /unknown: expected 404, got %d", resp3.StatusCode)
+	}
+}
+
+func TestMockCLI_MultiSchema(t *testing.T) {
+	petstore := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	ecommerce := schemaPath("server/testdata/openapi-v3/valid/complex-ecommerce.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", petstore, "--schema", ecommerce)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// GET /pets -> 200 (from petstore schema)
+	resp, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("GET /pets: expected 200, got %d", resp.StatusCode)
+	}
+
+	// GET /products -> 200 (from ecommerce schema)
+	resp2, err := http.Get(baseURL + "/products")
+	if err != nil {
+		t.Fatalf("GET /products failed: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Errorf("GET /products: expected 200, got %d", resp2.StatusCode)
+	}
+
+	// GET /unknown -> 404
+	resp3, err := http.Get(baseURL + "/unknown")
+	if err != nil {
+		t.Fatalf("GET /unknown failed: %v", err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Errorf("GET /unknown: expected 404, got %d", resp3.StatusCode)
+	}
+}
+
+func TestMockCLI_NoSchema(t *testing.T) {
+	cmd := exec.Command(testBinary, "mock")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit code when no --schema is provided")
+	}
+	if !strings.Contains(stderr.String(), "at least one --schema is required") {
+		t.Errorf("expected stderr to contain 'at least one --schema is required', got: %s", stderr.String())
+	}
+}
+
+func TestMockCLI_InvalidSchema(t *testing.T) {
+	malformed := schemaPath("server/testdata/openapi-v3/invalid/malformed-json.json")
+	cmd := exec.Command(testBinary, "mock", "--schema", malformed)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit code with invalid schema")
+	}
+}
+
+func TestMockCLI_CustomPort(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	port := getFreePort(t)
+
+	cmd := exec.Command(testBinary, "mock", "--schema", schema, "--port", fmt.Sprintf("%d", port), "--quiet")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	})
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ready := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/")
+		if err == nil {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("server did not start on custom port")
+	}
+
+	// Verify the server responds on the specified port
+	resp, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets on custom port failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("GET /pets on custom port: expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestMockCLI_InvalidPort(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	cmd := exec.Command(testBinary, "mock", "--schema", schema, "--port", "-1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit code with invalid port")
+	}
+	if !strings.Contains(stderr.String(), "invalid port") {
+		t.Errorf("expected stderr to contain 'invalid port', got: %s", stderr.String())
+	}
+}
+
+func TestMockCLI_ValidateRequests_Valid(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema, "--validate-requests")
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// POST /pets with valid body (NewPet requires "name")
+	body := `{"name":"Rex","tag":"dog"}`
+	resp, err := http.Post(baseURL+"/pets", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /pets failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /pets with valid body: expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+func TestMockCLI_ValidateRequests_Invalid(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema, "--validate-requests")
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// POST /pets with empty body (missing required "name" field)
+	body := `{}`
+	resp, err := http.Post(baseURL+"/pets", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /pets failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /pets with invalid body: expected 400, got %d: %s", resp.StatusCode, respBody)
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if !strings.Contains(string(respBody), "violations") {
+		t.Errorf("expected response to contain 'violations', got: %s", respBody)
+	}
+}
+
+func TestMockCLI_Latency(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema, "--latency", "200")
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	start := time.Now()
+	resp, err := http.Get(baseURL + "/pets")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("GET /pets failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("expected latency >= 200ms, got %s", elapsed)
+	}
+}
+
+func TestMockCLI_IndexPage(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	resp, err := http.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET / failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /: expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("GET /: expected Content-Type text/html, got %s", ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "CVT Mock Server") {
+		t.Error("GET /: expected body to contain 'CVT Mock Server'")
+	}
+	if !strings.Contains(bodyStr, "/pets") {
+		t.Error("GET /: expected body to contain '/pets'")
+	}
+}
+
+func TestMockCLI_CORS(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	_, port, _ := startMockServer(t, testBinary, "--schema", schema)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Send OPTIONS preflight with Origin header
+	req, err := http.NewRequest("OPTIONS", baseURL+"/pets", nil)
+	if err != nil {
+		t.Fatalf("failed to create OPTIONS request: %v", err)
+	}
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("OPTIONS /pets failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("OPTIONS /pets: expected 200, got %d", resp.StatusCode)
+	}
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin: *, got %q", acao)
+	}
+}
+
+func TestMockCLI_Quiet(t *testing.T) {
+	schema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	port := getFreePort(t)
+
+	// Start with explicit -q flag (not added by the helper)
+	cmd := exec.Command(testBinary, "mock", "--schema", schema, "--port", fmt.Sprintf("%d", port), "-q")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	})
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ready := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/")
+		if err == nil {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("server did not start with -q flag")
+	}
+
+	// Make a request to generate log output
+	resp, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("GET /pets: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Verify the server starts and responds (stdout should have no [mock] lines)
+	if strings.Contains(stdout.String(), "[mock]") {
+		t.Errorf("expected no [mock] log lines in quiet mode, got: %s", stdout.String())
+	}
+}
+
+func TestMockCLI_Watch(t *testing.T) {
+	// Copy the petstore schema to a temp directory
+	srcSchema := schemaPath("server/testdata/openapi-v3/valid/simple-petstore.json")
+	tmpDir := t.TempDir()
+	tmpSchema := filepath.Join(tmpDir, "petstore.json")
+
+	srcData, err := os.ReadFile(srcSchema)
+	if err != nil {
+		t.Fatalf("failed to read source schema: %v", err)
+	}
+	if err := os.WriteFile(tmpSchema, srcData, 0644); err != nil {
+		t.Fatalf("failed to write temp schema: %v", err)
+	}
+
+	_, port, _ := startMockServer(t, testBinary, "--schema", tmpSchema, "--watch")
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Verify GET /pets works
+	resp, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /pets: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Modify the schema: add a /health endpoint
+	var schema map[string]interface{}
+	if err := json.Unmarshal(srcData, &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+	paths, ok := schema["paths"].(map[string]interface{})
+	if !ok {
+		t.Fatal("schema paths is not a map")
+	}
+	paths["/health"] = map[string]interface{}{
+		"get": map[string]interface{}{
+			"summary":     "Health check",
+			"operationId": "healthCheck",
+			"responses": map[string]interface{}{
+				"200": map[string]interface{}{
+					"description": "OK",
+					"content": map[string]interface{}{
+						"application/json": map[string]interface{}{
+							"schema": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"status": map[string]interface{}{
+										"type": "string",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	modifiedData, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal modified schema: %v", err)
+	}
+	if err := os.WriteFile(tmpSchema, modifiedData, 0644); err != nil {
+		t.Fatalf("failed to write modified schema: %v", err)
+	}
+
+	// Wait for the watcher to detect changes and reload (up to 3 seconds)
+	time.Sleep(2 * time.Second)
+
+	// Verify old endpoints still work (server did not crash on reload)
+	resp2, err := http.Get(baseURL + "/pets")
+	if err != nil {
+		t.Fatalf("GET /pets after reload failed: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Errorf("GET /pets after reload: expected 200, got %d", resp2.StatusCode)
+	}
+
+	// Try the new endpoint - the watcher should have reloaded
+	resp3, err := http.Get(baseURL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health failed: %v", err)
+	}
+	resp3.Body.Close()
+	// If watcher reload worked, this will be 200; if not, it will be 404
+	// Either outcome is acceptable - the important thing is the server did not crash
+	if resp3.StatusCode != 200 && resp3.StatusCode != 404 {
+		t.Errorf("GET /health: expected 200 or 404, got %d", resp3.StatusCode)
+	}
+}

--- a/cmd/cvt/mock_test.go
+++ b/cmd/cvt/mock_test.go
@@ -26,8 +26,6 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(tmp)
-
 	bin := filepath.Join(tmp, "cvt")
 	cmd := exec.Command("go", "build", "-o", bin, "./")
 	cmd.Dir = filepath.Join(repoRoot())
@@ -40,7 +38,9 @@ func TestMain(m *testing.M) {
 	}
 
 	testBinary = bin
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
 }
 
 // repoRoot returns the absolute path to the repository root.
@@ -101,8 +101,9 @@ func startMockServer(t *testing.T, binary string, args ...string) (*exec.Cmd, in
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	ready := false
 	deadline := time.Now().Add(5 * time.Second)
+	pollClient := &http.Client{Timeout: 250 * time.Millisecond}
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(baseURL + "/")
+		resp, err := pollClient.Get(baseURL + "/")
 		if err == nil {
 			resp.Body.Close()
 			ready = true
@@ -533,28 +534,31 @@ func TestMockCLI_Watch(t *testing.T) {
 		t.Fatalf("failed to write modified schema: %v", err)
 	}
 
-	// Wait for the watcher to detect changes and reload (up to 3 seconds)
-	time.Sleep(2 * time.Second)
+	// Poll until the new /health endpoint returns 200 (proves reload worked)
+	healthReady := false
+	reloadDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(reloadDeadline) {
+		resp2, err := http.Get(baseURL + "/health")
+		if err == nil {
+			resp2.Body.Close()
+			if resp2.StatusCode == 200 {
+				healthReady = true
+				break
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !healthReady {
+		t.Fatal("GET /health: expected 200 after schema reload, watcher may not have reloaded")
+	}
 
-	// Verify old endpoints still work (server did not crash on reload)
-	resp2, err := http.Get(baseURL + "/pets")
+	// Verify old endpoints still work after reload
+	resp3, err := http.Get(baseURL + "/pets")
 	if err != nil {
 		t.Fatalf("GET /pets after reload failed: %v", err)
 	}
-	resp2.Body.Close()
-	if resp2.StatusCode != 200 {
-		t.Errorf("GET /pets after reload: expected 200, got %d", resp2.StatusCode)
-	}
-
-	// Try the new endpoint - the watcher should have reloaded
-	resp3, err := http.Get(baseURL + "/health")
-	if err != nil {
-		t.Fatalf("GET /health failed: %v", err)
-	}
 	resp3.Body.Close()
-	// If watcher reload worked, this will be 200; if not, it will be 404
-	// Either outcome is acceptable - the important thing is the server did not crash
-	if resp3.StatusCode != 200 && resp3.StatusCode != 404 {
-		t.Errorf("GET /health: expected 200 or 404, got %d", resp3.StatusCode)
+	if resp3.StatusCode != 200 {
+		t.Errorf("GET /pets after reload: expected 200, got %d", resp3.StatusCode)
 	}
 }

--- a/cmd/cvt/serve.go
+++ b/cmd/cvt/serve.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sahina/cvt/pkg/cvt"
+	"github.com/sahina/cvt/pkg/mock"
 	"github.com/sahina/cvt/server/cvtservice"
 	"github.com/sahina/cvt/server/pb"
 	"github.com/sahina/cvt/server/storage"
@@ -28,6 +30,7 @@ func serveCmd() *cobra.Command {
 	var (
 		port        int
 		metricsPort int
+		mockPort    int
 		tlsEnabled  bool
 		tlsCert     string
 		tlsKey      string
@@ -205,6 +208,49 @@ Examples:
 			reflection.Register(grpcServer)
 			cvtservice.Info("Registered ProtoReflectionService")
 
+			// Start mock HTTP server if --mock-port is specified
+			var mockServer *http.Server
+			if cmd.Flags().Changed("mock-port") || os.Getenv("CVT_MOCK_PORT") != "" {
+				resolvedMockPort := mockPort
+				if !cmd.Flags().Changed("mock-port") {
+					if mp, err := strconv.Atoi(os.Getenv("CVT_MOCK_PORT")); err == nil {
+						resolvedMockPort = mp
+					}
+				}
+
+				// Create a pkg/cvt Validator for mock serving
+				mockValidator := cvt.NewValidator()
+				var mockSchemaIDs []string
+
+				mockHandler := mock.NewMockHandler(mockValidator, mockSchemaIDs, mock.HandlerConfig{
+					UseExamples: true,
+					Quiet:       false,
+				})
+				indexH := mock.IndexHandler(mockValidator, mockSchemaIDs)
+
+				mockMux := http.NewServeMux()
+				mockMux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/" && r.Method == "GET" {
+						indexH.ServeHTTP(w, r)
+						return
+					}
+					mockHandler.ServeHTTP(w, r)
+				}))
+
+				mockServer = &http.Server{
+					Addr:         fmt.Sprintf(":%d", resolvedMockPort),
+					Handler:      mock.CORSMiddleware(mockMux),
+					ReadTimeout:  30 * time.Second,
+					WriteTimeout: 30 * time.Second,
+				}
+				go func() {
+					cvtservice.Info("Mock server listening", zap.String("address", mockServer.Addr))
+					if err := mockServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+						cvtservice.Error("Mock server failed", zap.Error(err))
+					}
+				}()
+			}
+
 			// Start Prometheus metrics HTTP server
 			metricsServer := &http.Server{
 				Addr:         fmt.Sprintf(":%d", metricsPort),
@@ -261,6 +307,17 @@ Examples:
 				cvtservice.Info("Metrics server stopped")
 			}
 
+			// Shutdown mock server if running
+			if mockServer != nil {
+				mockShutdownCtx, mockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer mockCancel()
+				if err := mockServer.Shutdown(mockShutdownCtx); err != nil {
+					cvtservice.Error("Failed to shutdown mock server", zap.Error(err))
+				} else {
+					cvtservice.Info("Mock server stopped")
+				}
+			}
+
 			// Perform graceful shutdown
 			cvtservice.Info("Shutting down server gracefully...")
 			grpcServer.GracefulStop()
@@ -272,6 +329,7 @@ Examples:
 
 	cmd.Flags().IntVarP(&port, "port", "p", 9550, "gRPC server port")
 	cmd.Flags().IntVar(&metricsPort, "metrics-port", 9551, "Metrics server port")
+	cmd.Flags().IntVar(&mockPort, "mock-port", 0, "Start mock HTTP server on this port (0 = disabled)")
 	cmd.Flags().BoolVar(&tlsEnabled, "tls", false, "Enable TLS")
 	cmd.Flags().StringVar(&tlsCert, "cert", "", "TLS certificate file")
 	cmd.Flags().StringVar(&tlsKey, "key", "", "TLS private key file")

--- a/cmd/cvt/serve.go
+++ b/cmd/cvt/serve.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sahina/cvt/pkg/cvt"
-	"github.com/sahina/cvt/pkg/mock"
 	"github.com/sahina/cvt/server/cvtservice"
 	"github.com/sahina/cvt/server/pb"
 	"github.com/sahina/cvt/server/storage"
@@ -30,7 +28,6 @@ func serveCmd() *cobra.Command {
 	var (
 		port        int
 		metricsPort int
-		mockPort    int
 		tlsEnabled  bool
 		tlsCert     string
 		tlsKey      string
@@ -208,49 +205,6 @@ Examples:
 			reflection.Register(grpcServer)
 			cvtservice.Info("Registered ProtoReflectionService")
 
-			// Start mock HTTP server if --mock-port is specified
-			var mockServer *http.Server
-			if cmd.Flags().Changed("mock-port") || os.Getenv("CVT_MOCK_PORT") != "" {
-				resolvedMockPort := mockPort
-				if !cmd.Flags().Changed("mock-port") {
-					if mp, err := strconv.Atoi(os.Getenv("CVT_MOCK_PORT")); err == nil {
-						resolvedMockPort = mp
-					}
-				}
-
-				// Create a pkg/cvt Validator for mock serving
-				mockValidator := cvt.NewValidator()
-				var mockSchemaIDs []string
-
-				mockHandler := mock.NewMockHandler(mockValidator, mockSchemaIDs, mock.HandlerConfig{
-					UseExamples: true,
-					Quiet:       false,
-				})
-				indexH := mock.IndexHandler(mockValidator, mockSchemaIDs)
-
-				mockMux := http.NewServeMux()
-				mockMux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/" && r.Method == "GET" {
-						indexH.ServeHTTP(w, r)
-						return
-					}
-					mockHandler.ServeHTTP(w, r)
-				}))
-
-				mockServer = &http.Server{
-					Addr:         fmt.Sprintf(":%d", resolvedMockPort),
-					Handler:      mock.CORSMiddleware(mockMux),
-					ReadTimeout:  30 * time.Second,
-					WriteTimeout: 30 * time.Second,
-				}
-				go func() {
-					cvtservice.Info("Mock server listening", zap.String("address", mockServer.Addr))
-					if err := mockServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-						cvtservice.Error("Mock server failed", zap.Error(err))
-					}
-				}()
-			}
-
 			// Start Prometheus metrics HTTP server
 			metricsServer := &http.Server{
 				Addr:         fmt.Sprintf(":%d", metricsPort),
@@ -307,17 +261,6 @@ Examples:
 				cvtservice.Info("Metrics server stopped")
 			}
 
-			// Shutdown mock server if running
-			if mockServer != nil {
-				mockShutdownCtx, mockCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer mockCancel()
-				if err := mockServer.Shutdown(mockShutdownCtx); err != nil {
-					cvtservice.Error("Failed to shutdown mock server", zap.Error(err))
-				} else {
-					cvtservice.Info("Mock server stopped")
-				}
-			}
-
 			// Perform graceful shutdown
 			cvtservice.Info("Shutting down server gracefully...")
 			grpcServer.GracefulStop()
@@ -329,7 +272,6 @@ Examples:
 
 	cmd.Flags().IntVarP(&port, "port", "p", 9550, "gRPC server port")
 	cmd.Flags().IntVar(&metricsPort, "metrics-port", 9551, "Metrics server port")
-	cmd.Flags().IntVar(&mockPort, "mock-port", 0, "Start mock HTTP server on this port (0 = disabled)")
 	cmd.Flags().BoolVar(&tlsEnabled, "tls", false, "Enable TLS")
 	cmd.Flags().StringVar(&tlsCert, "cert", "", "TLS certificate file")
 	cmd.Flags().StringVar(&tlsKey, "key", "", "TLS private key file")

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -44,7 +44,16 @@ See [Approach 3: Mock Client](../guides/consumer-testing.mdx#approach-3-mock-cli
 
 No — they're in-process test doubles, not a standalone HTTP server. The mock adapter intercepts HTTP calls inside your test and returns schema-generated responses without network overhead. This makes tests fast and deterministic. See the [adapter pattern](../reference/architecture/sdk-architecture.md#adapter-pattern) docs for how this works under the hood.
 
-If you need an actual running mock server (e.g., for manual testing or non-SDK languages), you can use CVT's [fixture generation](../guides/producer-testing.mdx#test-fixture-generation) via the [`cvt generate`](../reference/cli.mdx#generate) CLI command to produce response data and serve it however you like. But for automated testing, the in-process mock adapters are the recommended approach — they're simpler to set up, faster to run, and tightly integrated with CVT's validation pipeline.
+If you need an actual running HTTP mock server (e.g., for frontend development, manual testing, or non-SDK languages), use the [`cvt mock`](../reference/cli.mdx#mock) CLI command:
+
+```bash
+cvt mock --schema ./openapi.json
+# Mock server running on http://localhost:8080
+```
+
+It supports multiple schemas, request validation, hot-reload, latency simulation, and CORS headers out of the box. See the [CLI Reference](../reference/cli.mdx#mock) for all options.
+
+For automated testing, the in-process mock adapters remain the recommended approach — they're simpler to set up, faster to run, and tightly integrated with CVT's validation pipeline.
 
 ## How can I trust mock responses to match the real API?
 
@@ -58,6 +67,6 @@ The combination is powerful: mock adapters give consumers fast, offline feedback
 
 For some workflows, yes:
 
-- **CLI offline commands** (**server not needed**) — [`cvt validate`](../reference/cli.mdx#validate), [`cvt compare`](../reference/cli.mdx#compare), and [`cvt generate`](../reference/cli.mdx#generate) work entirely offline against local schema files or URLs.
+- **CLI offline commands** (**server not needed**) — [`cvt validate`](../reference/cli.mdx#validate), [`cvt compare`](../reference/cli.mdx#compare), [`cvt generate`](../reference/cli.mdx#generate), and [`cvt mock`](../reference/cli.mdx#mock) work entirely offline against local schema files or URLs.
 - **Embedded Go library** (**server not needed**) — [`pkg/cvt`](https://pkg.go.dev/github.com/sahina/cvt/pkg/cvt) can be imported directly into Go code for in-process validation without any network calls.
 - **SDK-based workflow** (**server needed**) — [`registerSchema`](../reference/sdk/index.mdx#initialization), [`validate`](../reference/sdk/index.mdx#validation), [consumer registration](../guides/consumer-testing.mdx), and [`can-i-deploy`](../reference/cli.mdx#can-i-deploy) require a running server since SDKs communicate over [gRPC](../reference/api.mdx#service-methods).

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -67,6 +67,6 @@ The combination is powerful: mock adapters give consumers fast, offline feedback
 
 For some workflows, yes:
 
-- **CLI offline commands** (**server not needed**) — [`cvt validate`](../reference/cli.mdx#validate), [`cvt compare`](../reference/cli.mdx#compare), [`cvt generate`](../reference/cli.mdx#generate), and [`cvt mock`](../reference/cli.mdx#mock) work entirely offline against local schema files or URLs.
+- **CLI offline commands** (**server not needed**) — [`cvt validate`](../reference/cli.mdx#validate), [`cvt compare`](../reference/cli.mdx#compare), [`cvt generate`](../reference/cli.mdx#generate), and [`cvt mock`](../reference/cli.mdx#mock) work without a CVT server. They operate on local schema files directly (or fetch from a URL if one is provided).
 - **Embedded Go library** (**server not needed**) — [`pkg/cvt`](https://pkg.go.dev/github.com/sahina/cvt/pkg/cvt) can be imported directly into Go code for in-process validation without any network calls.
 - **SDK-based workflow** (**server needed**) — [`registerSchema`](../reference/sdk/index.mdx#initialization), [`validate`](../reference/sdk/index.mdx#validation), [consumer registration](../guides/consumer-testing.mdx), and [`can-i-deploy`](../reference/cli.mdx#can-i-deploy) require a running server since SDKs communicate over [gRPC](../reference/api.mdx#service-methods).

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -345,6 +345,23 @@ EOF
 cvt validate --schema openapi.json --request request.json --response response.json
 ```
 
+### Mock Server
+
+Start a mock HTTP server from any OpenAPI schema — useful for frontend development, manual testing, or mocking upstream APIs:
+
+```bash
+# Start mock server on port 8080
+cvt mock --schema openapi.json
+
+# With request validation and hot-reload
+cvt mock --schema openapi.json --validate-requests --watch
+
+# Test it
+curl http://localhost:8080/pet/123
+```
+
+See the [CLI Reference](../reference/cli.mdx#mock) for all mock server options.
+
 ## What's Next?
 
 Now that you've validated your first interaction, explore:

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -479,6 +479,15 @@ validator.close();
 
 Use the mock adapter for tests without a real API:
 
+:::tip Standalone Mock Server
+Need a running HTTP server instead of an in-process mock? Use [`cvt mock`](../reference/cli.mdx#mock) to start a standalone mock server from any OpenAPI schema — great for frontend development, manual testing, or non-SDK languages:
+
+```bash
+cvt mock --schema ./openapi.json --validate-requests --watch
+```
+
+:::
+
 <Tabs groupId="sdk-language">
 <TabItem value="nodejs" label="Node.js">
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -285,7 +285,7 @@ cvt mock --schema <path-or-url> [options]
 
 | Flag                  | Short | Description                                           | Default   |
 | --------------------- | ----- | ----------------------------------------------------- | --------- |
-| `--schema`            | `-s`  | OpenAPI schema file path or URL (repeatable)          | (required)|
+| `--schema`            |       | OpenAPI schema file path or URL (repeatable)          | (required)|
 | `--port`              | `-p`  | HTTP server port                                      | 8080      |
 | `--host`              |       | Bind address                                          | 127.0.0.1 |
 | `--watch`             | `-w`  | Watch schema files for changes and hot-reload         | false     |

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -14,6 +14,7 @@ The CVT CLI lets you validate contracts locally without running a server. Use it
 - Quick one-off validations during development
 - CI/CD pipelines that need schema comparison
 - Generating test fixtures from OpenAPI schemas
+- Running a mock HTTP server from OpenAPI schemas
 - Starting a CVT server for remote validation
 
 ## Installation
@@ -33,6 +34,7 @@ go install github.com/sahina/cvt/cmd/cvt@latest
 | `validate`        | Validate an interaction against a schema             |
 | `compare`         | Compare schemas for breaking changes                 |
 | `generate`        | Generate test fixtures from schemas                  |
+| `mock`            | Start a mock HTTP server from OpenAPI schemas        |
 | `can-i-deploy`    | Check deployment safety against registered consumers |
 | `wait`            | Wait for CVT server to become ready                  |
 | `register-schema` | Register an OpenAPI schema with the server           |
@@ -281,6 +283,72 @@ Available endpoints:
   PUT /pets/{petId}
   DELETE /pets/{petId}
 ```
+
+---
+
+## mock
+
+Start an HTTP mock server that generates responses from OpenAPI schemas. The server matches incoming requests to schema operations and returns spec-compliant responses with CORS headers for frontend development.
+
+### Usage
+
+```bash
+cvt mock --schema <path-or-url> [options]
+```
+
+### Options
+
+| Flag                  | Short | Description                                           | Default   |
+| --------------------- | ----- | ----------------------------------------------------- | --------- |
+| `--schema`            | `-s`  | OpenAPI schema file path or URL (repeatable)          | (required)|
+| `--port`              | `-p`  | HTTP server port                                      | 8080      |
+| `--host`              |       | Bind address                                          | 127.0.0.1 |
+| `--watch`             | `-w`  | Watch schema files for changes and hot-reload         | false     |
+| `--validate-requests` |       | Validate incoming requests against the schema         | false     |
+| `--no-examples`       |       | Use generated values instead of schema examples       | false     |
+| `--latency`           |       | Artificial response delay in milliseconds             | 0         |
+| `--quiet`             | `-q`  | Suppress request logging                              | false     |
+
+### Examples
+
+```bash
+# Basic mock server on default port 8080
+cvt mock --schema ./openapi.json
+
+# Multiple schemas on a custom port
+cvt mock --schema users.json --schema orders.json --port 3000
+
+# With request validation and hot-reload during development
+cvt mock --schema ./openapi.json --validate-requests --watch
+
+# Mock from a remote URL
+cvt mock --schema https://petstore3.swagger.io/api/v3/openapi.json
+
+# Simulate 200ms network latency
+cvt mock --schema ./openapi.json --latency 200
+
+# Quiet mode (no per-request logging)
+cvt mock --schema ./openapi.json --quiet
+```
+
+### How It Works
+
+1. Parses and loads all provided OpenAPI schemas
+2. Builds a route table from all schema operations
+3. Matches each incoming HTTP request to a schema operation
+4. Returns a generated response using schema examples (or synthetic values with `--no-examples`)
+5. Adds CORS headers (`Access-Control-Allow-Origin: *`) to all responses
+
+When `--validate-requests` is enabled, the server validates incoming requests against the schema and returns `400 Bad Request` with details if validation fails.
+
+When `--watch` is enabled, the server watches schema files on disk for changes and automatically reloads them without restart.
+
+### Exit Codes
+
+| Code | Meaning                                |
+| ---- | -------------------------------------- |
+| 0    | Server shut down cleanly               |
+| 1    | Failed to start (invalid schema, etc.) |
 
 ---
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -31,122 +31,107 @@ go install github.com/sahina/cvt/cmd/cvt@latest
 
 | Command           | Description                                          |
 | ----------------- | ---------------------------------------------------- |
-| `validate`        | Validate an interaction against a schema             |
+| `can-i-deploy`    | Check deployment safety against registered consumers |
 | `compare`         | Compare schemas for breaking changes                 |
 | `generate`        | Generate test fixtures from schemas                  |
 | `mock`            | Start a mock HTTP server from OpenAPI schemas        |
-| `can-i-deploy`    | Check deployment safety against registered consumers |
-| `wait`            | Wait for CVT server to become ready                  |
 | `register-schema` | Register an OpenAPI schema with the server           |
 | `serve`           | Start the server                                     |
+| `validate`        | Validate an interaction against a schema             |
 | `version`         | Show version information                             |
+| `wait`            | Wait for CVT server to become ready                  |
 
 ---
 
-## validate
+## can-i-deploy
 
-Validate an HTTP request/response interaction against an OpenAPI schema.
+Check if a schema version can be safely deployed without breaking registered consumers.
 
 ### Usage
 
 ```bash
-cvt validate --schema <path> [options]
+cvt can-i-deploy --schema <id> --version <version> --env <environment> [options]
 ```
 
 ### Options
 
-| Flag              | Short | Description                               | Required                             |
-| ----------------- | ----- | ----------------------------------------- | ------------------------------------ |
-| `--schema`        | `-s`  | Path or URL to OpenAPI schema (JSON/YAML) | Yes                                  |
-| `--interaction`   | `-i`  | Path to combined interaction JSON file    | No (alternative to request/response) |
-| `--request`       |       | Path to request JSON file                 | No (use with --response)             |
-| `--response`      |       | Path to response JSON file                | No (use with --request)              |
-| `--method`        | `-m`  | HTTP method (GET, POST, etc.)             | No (alternative to files)            |
-| `--path`          | `-p`  | Request path (e.g., /pets/123)            | No (use with --method)               |
-| `--request-body`  |       | Request body as JSON string               | No                                   |
-| `--status-code`   |       | Response status code (default: 200)       | No                                   |
-| `--response-body` |       | Response body as JSON string              | No                                   |
-| `--json`          |       | Output results as JSON                    | No                                   |
+| Flag        | Description                             | Required | Default        |
+| ----------- | --------------------------------------- | -------- | -------------- |
+| `--schema`  | Schema ID to check                      | Yes      |                |
+| `--version` | New version to deploy                   | Yes      |                |
+| `--env`     | Target environment (dev, staging, prod) | Yes      |                |
+| `--server`  | CVT server address                      | No       | localhost:9550 |
+| `--json`    | Output results as JSON                  | No       | false          |
+| `--timeout` | Connection timeout in seconds           | No       | 30             |
 
-### Input Methods
-
-You can provide interaction data in three ways:
-
-**1. Combined interaction file:**
+### Examples
 
 ```bash
-cvt validate --schema ./openapi.json --interaction interaction.json
+# Check deployment safety against local server
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
+
+# Check against a remote server
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --server cvt.internal:9550
+
+# JSON output for CI/CD
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --json
+
+# Custom timeout
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --timeout 60
 ```
 
-**2. Separate request/response files:**
+### Output (Safe)
 
-```bash
-cvt validate --schema ./openapi.json --request req.json --response resp.json
+```text
+Deployment Safety Check
+=======================
+Schema:      petstore
+Version:     2.0.0
+Environment: prod
+
+✅ SAFE TO DEPLOY
+
+No breaking changes detected that would affect registered consumers.
 ```
 
-**3. Command-line flags (for simple cases):**
+### Output (Unsafe)
 
-```bash
-cvt validate --schema ./openapi.json \
-  --method GET --path /pets/123 \
-  --status-code 200 --response-body '{"id": 123, "name": "doggie"}'
-```
+```text
+Deployment Safety Check
+=======================
+Schema:      petstore
+Version:     2.0.0
+Environment: prod
 
-**4. Using a URL for the schema:**
+❌ UNSAFE TO DEPLOY
 
-```bash
-cvt validate --schema https://petstore3.swagger.io/api/v3/openapi.json \
-  --interaction interaction.json
-```
+Breaking changes in v2.0.0:
+  - ENDPOINT_REMOVED: DELETE /pets/{petId}
+    Endpoint was removed from the API
 
-### Request File Format
+Affected consumers in prod:
+├── order-service v2.1.0
+│   Schema version: 1.0.0
+│   Impact: BREAKING
+│   Affected by:
+│     - DELETE /pets/{petId}
+│
+└── billing-service v1.0.0
+    Schema version: 1.0.0
+    Impact: None
 
-```json
-{
-  "method": "GET",
-  "path": "/pets/123",
-  "headers": {
-    "Accept": "application/json"
-  },
-  "body": null
-}
-```
+Safe consumers:     1/2
+Affected consumers: 1/2
 
-### Response File Format
-
-```json
-{
-  "status_code": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": "{\"id\": 123, \"name\": \"doggie\"}"
-}
-```
-
-### Interaction File Format
-
-```json
-{
-  "request": {
-    "method": "GET",
-    "path": "/pets/123",
-    "headers": { "Accept": "application/json" }
-  },
-  "response": {
-    "statusCode": 200,
-    "headers": { "Content-Type": "application/json" },
-    "body": { "id": 123, "name": "doggie" }
-  }
-}
+Recommendation: Coordinate with order-service team before deploying.
 ```
 
 ### Exit Codes
 
-| Code | Meaning                            |
-| ---- | ---------------------------------- |
-| 0    | Validation passed                  |
-| 1    | Validation failed (errors printed) |
+| Code | Meaning                                              |
+| ---- | ---------------------------------------------------- |
+| 0    | Safe to deploy                                       |
+| 1    | Unsafe to deploy (breaking changes affect consumers) |
 
 ---
 
@@ -352,149 +337,6 @@ When `--watch` is enabled, the server watches schema files on disk for changes a
 
 ---
 
-## can-i-deploy
-
-Check if a schema version can be safely deployed without breaking registered consumers.
-
-### Usage
-
-```bash
-cvt can-i-deploy --schema <id> --version <version> --env <environment> [options]
-```
-
-### Options
-
-| Flag        | Description                             | Required | Default        |
-| ----------- | --------------------------------------- | -------- | -------------- |
-| `--schema`  | Schema ID to check                      | Yes      |                |
-| `--version` | New version to deploy                   | Yes      |                |
-| `--env`     | Target environment (dev, staging, prod) | Yes      |                |
-| `--server`  | CVT server address                      | No       | localhost:9550 |
-| `--json`    | Output results as JSON                  | No       | false          |
-| `--timeout` | Connection timeout in seconds           | No       | 30             |
-
-### Examples
-
-```bash
-# Check deployment safety against local server
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
-
-# Check against a remote server
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --server cvt.internal:9550
-
-# JSON output for CI/CD
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --json
-
-# Custom timeout
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --timeout 60
-```
-
-### Output (Safe)
-
-```text
-Deployment Safety Check
-=======================
-Schema:      petstore
-Version:     2.0.0
-Environment: prod
-
-✅ SAFE TO DEPLOY
-
-No breaking changes detected that would affect registered consumers.
-```
-
-### Output (Unsafe)
-
-```text
-Deployment Safety Check
-=======================
-Schema:      petstore
-Version:     2.0.0
-Environment: prod
-
-❌ UNSAFE TO DEPLOY
-
-Breaking changes in v2.0.0:
-  - ENDPOINT_REMOVED: DELETE /pets/{petId}
-    Endpoint was removed from the API
-
-Affected consumers in prod:
-├── order-service v2.1.0
-│   Schema version: 1.0.0
-│   Impact: BREAKING
-│   Affected by:
-│     - DELETE /pets/{petId}
-│
-└── billing-service v1.0.0
-    Schema version: 1.0.0
-    Impact: None
-
-Safe consumers:     1/2
-Affected consumers: 1/2
-
-Recommendation: Coordinate with order-service team before deploying.
-```
-
-### Exit Codes
-
-| Code | Meaning                                              |
-| ---- | ---------------------------------------------------- |
-| 0    | Safe to deploy                                       |
-| 1    | Unsafe to deploy (breaking changes affect consumers) |
-
----
-
-## wait
-
-Wait for the CVT server to become ready. Useful for CI/CD pipelines and startup scripts.
-
-### Usage
-
-```bash
-cvt wait [options]
-```
-
-### Options
-
-| Flag         | Short | Description                   | Default        |
-| ------------ | ----- | ----------------------------- | -------------- |
-| `--server`   | `-S`  | CVT server address            | localhost:9550 |
-| `--timeout`  | `-t`  | Timeout in seconds            | 60             |
-| `--interval` | `-i`  | Polling interval in seconds   | 2              |
-| `--json`     | `-j`  | Output results as JSON        | false          |
-| `--quiet`    | `-q`  | Suppress output except errors | false          |
-
-### Examples
-
-```bash
-# Wait with defaults (60s timeout, 2s interval)
-cvt wait
-
-# Wait for specific server with custom timeout
-cvt wait --server cvt.internal:9550 --timeout 120
-
-# Custom polling interval
-cvt wait --server localhost:9550 --timeout 120 --interval 1
-
-# Short flags
-cvt wait -S localhost:9550 -t 120 -i 1
-
-# Quiet mode for CI/CD
-cvt wait -q
-
-# JSON output for scripting
-cvt wait --json
-```
-
-### Exit Codes
-
-| Code | Meaning                    |
-| ---- | -------------------------- |
-| 0    | Server is ready            |
-| 1    | Timeout waiting for server |
-
----
-
 ## register-schema
 
 Register an OpenAPI schema with the CVT server. Supports both local files and URLs, and can check for breaking changes before registering.
@@ -609,6 +451,113 @@ The serve command also respects environment variables. See [Configuration Refere
 
 ---
 
+## validate
+
+Validate an HTTP request/response interaction against an OpenAPI schema.
+
+### Usage
+
+```bash
+cvt validate --schema <path> [options]
+```
+
+### Options
+
+| Flag              | Short | Description                               | Required                             |
+| ----------------- | ----- | ----------------------------------------- | ------------------------------------ |
+| `--schema`        | `-s`  | Path or URL to OpenAPI schema (JSON/YAML) | Yes                                  |
+| `--interaction`   | `-i`  | Path to combined interaction JSON file    | No (alternative to request/response) |
+| `--request`       |       | Path to request JSON file                 | No (use with --response)             |
+| `--response`      |       | Path to response JSON file                | No (use with --request)              |
+| `--method`        | `-m`  | HTTP method (GET, POST, etc.)             | No (alternative to files)            |
+| `--path`          | `-p`  | Request path (e.g., /pets/123)            | No (use with --method)               |
+| `--request-body`  |       | Request body as JSON string               | No                                   |
+| `--status-code`   |       | Response status code (default: 200)       | No                                   |
+| `--response-body` |       | Response body as JSON string              | No                                   |
+| `--json`          |       | Output results as JSON                    | No                                   |
+
+### Input Methods
+
+You can provide interaction data in three ways:
+
+**1. Combined interaction file:**
+
+```bash
+cvt validate --schema ./openapi.json --interaction interaction.json
+```
+
+**2. Separate request/response files:**
+
+```bash
+cvt validate --schema ./openapi.json --request req.json --response resp.json
+```
+
+**3. Command-line flags (for simple cases):**
+
+```bash
+cvt validate --schema ./openapi.json \
+  --method GET --path /pets/123 \
+  --status-code 200 --response-body '{"id": 123, "name": "doggie"}'
+```
+
+**4. Using a URL for the schema:**
+
+```bash
+cvt validate --schema https://petstore3.swagger.io/api/v3/openapi.json \
+  --interaction interaction.json
+```
+
+### Request File Format
+
+```json
+{
+  "method": "GET",
+  "path": "/pets/123",
+  "headers": {
+    "Accept": "application/json"
+  },
+  "body": null
+}
+```
+
+### Response File Format
+
+```json
+{
+  "status_code": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": "{\"id\": 123, \"name\": \"doggie\"}"
+}
+```
+
+### Interaction File Format
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "path": "/pets/123",
+    "headers": { "Accept": "application/json" }
+  },
+  "response": {
+    "statusCode": 200,
+    "headers": { "Content-Type": "application/json" },
+    "body": { "id": 123, "name": "doggie" }
+  }
+}
+```
+
+### Exit Codes
+
+| Code | Meaning                            |
+| ---- | ---------------------------------- |
+| 0    | Validation passed                  |
+| 1    | Validation failed (errors printed) |
+
+---
+
 ## version
 
 Display version information.
@@ -626,6 +575,57 @@ CVT version 1.0.0
   Commit:  abc1234
   Built:   2024-01-15T10:30:00Z
 ```
+
+---
+
+## wait
+
+Wait for the CVT server to become ready. Useful for CI/CD pipelines and startup scripts.
+
+### Usage
+
+```bash
+cvt wait [options]
+```
+
+### Options
+
+| Flag         | Short | Description                   | Default        |
+| ------------ | ----- | ----------------------------- | -------------- |
+| `--server`   | `-S`  | CVT server address            | localhost:9550 |
+| `--timeout`  | `-t`  | Timeout in seconds            | 60             |
+| `--interval` | `-i`  | Polling interval in seconds   | 2              |
+| `--json`     | `-j`  | Output results as JSON        | false          |
+| `--quiet`    | `-q`  | Suppress output except errors | false          |
+
+### Examples
+
+```bash
+# Wait with defaults (60s timeout, 2s interval)
+cvt wait
+
+# Wait for specific server with custom timeout
+cvt wait --server cvt.internal:9550 --timeout 120
+
+# Custom polling interval
+cvt wait --server localhost:9550 --timeout 120 --interval 1
+
+# Short flags
+cvt wait -S localhost:9550 -t 120 -i 1
+
+# Quiet mode for CI/CD
+cvt wait -q
+
+# JSON output for scripting
+cvt wait --json
+```
+
+### Exit Codes
+
+| Code | Meaning                    |
+| ---- | -------------------------- |
+| 0    | Server is ready            |
+| 1    | Timeout waiting for server |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/dgraph-io/ristretto v0.2.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
@@ -22,7 +23,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WA
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/getkin/kin-openapi v0.134.0 h1:/L5+1+kfe6dXh8Ot/wqiTgUkjOIEJiC0bbYVziHB8rU=
 github.com/getkin/kin-openapi v0.134.0/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/pkg/cvt/generator.go
+++ b/pkg/cvt/generator.go
@@ -465,7 +465,16 @@ func (v *Validator) generateValue(doc *openapi3.T, schemaRef *openapi3.SchemaRef
 	}
 
 	// Handle by type
-	switch schema.Type.Slice()[0] {
+	types := schema.Type.Slice()
+	if len(types) == 0 {
+		// Type-less schema (valid in OpenAPI 3.1 with composition)
+		if len(schema.Properties) > 0 {
+			return v.generateObject(doc, schema, useExamples, depth)
+		}
+		return nil
+	}
+
+	switch types[0] {
 	case "object":
 		return v.generateObject(doc, schema, useExamples, depth)
 	case "array":
@@ -479,7 +488,6 @@ func (v *Validator) generateValue(doc *openapi3.T, schemaRef *openapi3.SchemaRef
 	case "boolean":
 		return v.generateBoolean(schema)
 	default:
-		// Check if properties exist (implicit object)
 		if len(schema.Properties) > 0 {
 			return v.generateObject(doc, schema, useExamples, depth)
 		}

--- a/pkg/cvt/generator.go
+++ b/pkg/cvt/generator.go
@@ -503,6 +503,15 @@ func (v *Validator) generateObject(doc *openapi3.T, schema *openapi3.Schema, use
 		result[propName] = v.generateValue(doc, propRef, useExamples, depth+1)
 	}
 
+	// When there are no named properties but additionalProperties has a schema,
+	// generate sample entries so the response isn't an empty object.
+	if len(result) == 0 && schema.AdditionalProperties.Schema != nil {
+		sampleKeys := []string{"key1", "key2", "key3"}
+		for _, k := range sampleKeys {
+			result[k] = v.generateValue(doc, schema.AdditionalProperties.Schema, useExamples, depth+1)
+		}
+	}
+
 	return result
 }
 

--- a/pkg/cvt/generator_test.go
+++ b/pkg/cvt/generator_test.go
@@ -553,3 +553,89 @@ func TestGenerateResponse_RouteNotFound(t *testing.T) {
 		t.Error("expected error for non-existent route")
 	}
 }
+
+func TestGenerateValue_TypelessSchemaWithProperties(t *testing.T) {
+	schema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "properties": {
+	                    "name": {"type": "string"},
+	                    "age": {"type": "integer"}
+	                  }
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("typeless", []byte(schema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("typeless", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	body, ok := resp.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected object body for schema with properties, got %T", resp.Body)
+	}
+	if body["name"] == nil {
+		t.Error("expected 'name' field in generated object")
+	}
+}
+
+func TestGenerateValue_TypelessSchemaNoProperties(t *testing.T) {
+	schema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {}
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("typeless-empty", []byte(schema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("typeless-empty", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+	_ = resp
+}

--- a/pkg/cvt/generator_test.go
+++ b/pkg/cvt/generator_test.go
@@ -554,6 +554,128 @@ func TestGenerateResponse_RouteNotFound(t *testing.T) {
 	}
 }
 
+func TestGenerateObject_AdditionalProperties(t *testing.T) {
+	// Regression test: schemas with additionalProperties but no named properties
+	// (like Petstore's GET /store/inventory) should generate sample entries,
+	// not an empty object.
+	schema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/store/inventory": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "type": "object",
+	                  "additionalProperties": {
+	                    "type": "integer",
+	                    "format": "int32"
+	                  }
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("inventory", []byte(schema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("inventory", "GET", "/store/inventory", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	body, ok := resp.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected object body, got %T", resp.Body)
+	}
+
+	if len(body) == 0 {
+		t.Fatal("expected non-empty object for schema with additionalProperties, got {}")
+	}
+
+	// Each value should be an integer
+	for k, val := range body {
+		switch val.(type) {
+		case int64, float64, int:
+			// ok
+		default:
+			t.Errorf("key %q: expected integer value, got %T (%v)", k, val, val)
+		}
+	}
+}
+
+func TestGenerateObject_AdditionalPropertiesWithNamedProperties(t *testing.T) {
+	// When there ARE named properties, additionalProperties should NOT add synthetic keys
+	schema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "type": "object",
+	                  "properties": {
+	                    "name": {"type": "string"}
+	                  },
+	                  "additionalProperties": {
+	                    "type": "string"
+	                  }
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("mixed", []byte(schema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("mixed", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	body, ok := resp.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected object body, got %T", resp.Body)
+	}
+
+	// Should only have the named property, not synthetic keys
+	if _, ok := body["name"]; !ok {
+		t.Error("expected 'name' field")
+	}
+	if _, ok := body["key1"]; ok {
+		t.Error("should not generate synthetic keys when named properties exist")
+	}
+}
+
 func TestGenerateValue_TypelessSchemaWithProperties(t *testing.T) {
 	schema := `{
 	  "openapi": "3.0.0",

--- a/pkg/cvt/validator.go
+++ b/pkg/cvt/validator.go
@@ -192,7 +192,8 @@ func (v *Validator) prepareAndFindRoute(doc *openapi3.T, method, path string, he
 	// Derive base URL from server definitions
 	baseURL := "http://localhost"
 	if len(doc.Servers) > 0 {
-		if serverURL, err := url.Parse(doc.Servers[0].URL); err == nil {
+		if serverURL, err := url.Parse(doc.Servers[0].URL); err == nil &&
+			serverURL.Scheme != "" && serverURL.Host != "" {
 			baseURL = fmt.Sprintf("%s://%s", serverURL.Scheme, serverURL.Host)
 		}
 	}

--- a/pkg/cvt/validator.go
+++ b/pkg/cvt/validator.go
@@ -167,12 +167,16 @@ func (v *Validator) ValidateWithSchema(schemaContent []byte, interaction *Intera
 	return v.validateInteraction(doc, interaction)
 }
 
-func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interaction) (*ValidationResult, error) {
-	var result ValidationResult
-	result.Valid = true
-
+// prepareAndFindRoute handles basePath stripping, HTTP request construction,
+// doc.Servers cloning (thread safety), router creation, and route finding.
+//
+// Returns:
+//   - httpReq, requestValidationInput, nil, nil on success (route found)
+//   - httpReq, nil, routeNotFoundResult, nil when route not found (ValidationResult with Valid=false)
+//   - nil, nil, nil, err on hard error (failed to create request/router)
+func (v *Validator) prepareAndFindRoute(doc *openapi3.T, method, path string, headers map[string]string, body io.Reader) (*http.Request, *openapi3filter.RequestValidationInput, *ValidationResult, error) {
 	// Handle basePath from Swagger 2.0 schemas
-	requestPath := interaction.Path
+	requestPath := path
 	if len(doc.Servers) > 0 {
 		for _, server := range doc.Servers {
 			if serverURL, err := url.Parse(server.URL); err == nil && serverURL.Path != "" && serverURL.Path != "/" {
@@ -185,12 +189,7 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 		}
 	}
 
-	// Create HTTP request
-	var body io.Reader
-	if interaction.Body != "" {
-		body = strings.NewReader(interaction.Body)
-	}
-
+	// Derive base URL from server definitions
 	baseURL := "http://localhost"
 	if len(doc.Servers) > 0 {
 		if serverURL, err := url.Parse(doc.Servers[0].URL); err == nil {
@@ -198,12 +197,12 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 		}
 	}
 
-	httpReq, err := http.NewRequest(interaction.Method, baseURL+requestPath, body)
+	httpReq, err := http.NewRequest(method, baseURL+requestPath, body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	for k, val := range interaction.Headers {
+	for k, val := range headers {
 		httpReq.Header.Set(k, val)
 	}
 
@@ -232,29 +231,46 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 	// Create router from the clone (original doc is never mutated)
 	router, err := gorillamux.NewRouter(&routingDoc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create router: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create router: %w", err)
 	}
 
 	// Find route
 	route, pathParams, err := router.FindRoute(httpReq)
 	if err != nil {
-		result.Valid = false
-		result.Errors = append(result.Errors, fmt.Sprintf("route not found: %v", err))
-		return &result, nil
+		return httpReq, nil, &ValidationResult{
+			Valid:  false,
+			Errors: []string{fmt.Sprintf("route not found: %v", err)},
+		}, nil
 	}
 
-	// Validate request
-	ctx := context.Background()
 	requestValidationInput := &openapi3filter.RequestValidationInput{
 		Request:    httpReq,
 		PathParams: pathParams,
 		Route:      route,
 	}
 
+	return httpReq, requestValidationInput, nil, nil
+}
+
+func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interaction) (*ValidationResult, error) {
+	// Prepare body reader
+	var body io.Reader
+	if interaction.Body != "" {
+		body = strings.NewReader(interaction.Body)
+	}
+
+	_, requestValidationInput, routeResult, err := v.prepareAndFindRoute(doc, interaction.Method, interaction.Path, interaction.Headers, body)
+	if err != nil {
+		return nil, err
+	}
+	if routeResult != nil {
+		return routeResult, nil
+	}
+
+	// Validate request
+	ctx := context.Background()
 	if err := openapi3filter.ValidateRequest(ctx, requestValidationInput); err != nil {
-		result.Valid = false
-		result.Errors = append(result.Errors, err.Error())
-		return &result, nil
+		return &ValidationResult{Valid: false, Errors: []string{err.Error()}}, nil
 	}
 
 	// Validate response
@@ -271,12 +287,10 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 	}
 
 	if err := openapi3filter.ValidateResponse(ctx, responseValidationInput); err != nil {
-		result.Valid = false
-		result.Errors = append(result.Errors, err.Error())
-		return &result, nil
+		return &ValidationResult{Valid: false, Errors: []string{err.Error()}}, nil
 	}
 
-	return &result, nil
+	return &ValidationResult{Valid: true}, nil
 }
 
 // ValidateRequest validates only the HTTP request (no response) against a registered schema.
@@ -290,95 +304,27 @@ func (v *Validator) ValidateRequest(schemaID, method, path string, headers map[s
 		return nil, fmt.Errorf("schema not found: %s", schemaID)
 	}
 
-	var result ValidationResult
-	result.Valid = true
-
-	// Handle basePath from Swagger 2.0 schemas
-	requestPath := path
-	if len(doc.Servers) > 0 {
-		for _, server := range doc.Servers {
-			if serverURL, err := url.Parse(server.URL); err == nil && serverURL.Path != "" && serverURL.Path != "/" {
-				basePath := strings.TrimSuffix(serverURL.Path, "/")
-				if strings.HasPrefix(requestPath, basePath+"/") {
-					requestPath = strings.TrimPrefix(requestPath, basePath)
-					break
-				}
-			}
-		}
-	}
-
-	// Create HTTP request
+	// Prepare body reader
 	var bodyReader io.Reader
 	if body != "" {
 		bodyReader = strings.NewReader(body)
 	}
 
-	baseURL := "http://localhost"
-	if len(doc.Servers) > 0 {
-		if serverURL, err := url.Parse(doc.Servers[0].URL); err == nil {
-			baseURL = fmt.Sprintf("%s://%s", serverURL.Scheme, serverURL.Host)
-		}
-	}
-
-	httpReq, err := http.NewRequest(method, baseURL+requestPath, bodyReader)
+	_, requestValidationInput, routeResult, err := v.prepareAndFindRoute(doc, method, path, headers, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, err
 	}
-
-	for k, val := range headers {
-		httpReq.Header.Set(k, val)
-	}
-
-	// Create a shallow clone of the doc with stripped server URLs for routing.
-	routingDoc := *doc
-	if len(doc.Servers) > 0 {
-		modifiedServers := make(openapi3.Servers, 0, len(doc.Servers))
-		for _, server := range doc.Servers {
-			if serverURL, err := url.Parse(server.URL); err == nil {
-				serverURL.Path = ""
-				serverURL.RawPath = ""
-				newServer := &openapi3.Server{
-					URL:         serverURL.String(),
-					Description: server.Description,
-					Variables:   server.Variables,
-				}
-				modifiedServers = append(modifiedServers, newServer)
-			} else {
-				modifiedServers = append(modifiedServers, server)
-			}
-		}
-		routingDoc.Servers = modifiedServers
-	}
-
-	// Create router from the clone (original doc is never mutated)
-	router, err := gorillamux.NewRouter(&routingDoc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create router: %w", err)
-	}
-
-	// Find route
-	route, pathParams, err := router.FindRoute(httpReq)
-	if err != nil {
-		result.Valid = false
-		result.Errors = append(result.Errors, fmt.Sprintf("route not found: %v", err))
-		return &result, nil
+	if routeResult != nil {
+		return routeResult, nil
 	}
 
 	// Validate request only (no response validation)
 	ctx := context.Background()
-	requestValidationInput := &openapi3filter.RequestValidationInput{
-		Request:    httpReq,
-		PathParams: pathParams,
-		Route:      route,
-	}
-
 	if err := openapi3filter.ValidateRequest(ctx, requestValidationInput); err != nil {
-		result.Valid = false
-		result.Errors = append(result.Errors, err.Error())
-		return &result, nil
+		return &ValidationResult{Valid: false, Errors: []string{err.Error()}}, nil
 	}
 
-	return &result, nil
+	return &ValidationResult{Valid: true}, nil
 }
 
 // parseSchema parses OpenAPI v2 or v3 schema content.

--- a/pkg/cvt/validator.go
+++ b/pkg/cvt/validator.go
@@ -207,8 +207,9 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 		httpReq.Header.Set(k, val)
 	}
 
-	// Temporarily strip basePath from server URLs for routing
-	originalServers := doc.Servers
+	// Create a shallow clone of the doc with stripped server URLs for routing.
+	// This avoids mutating doc.Servers in place, which is not thread-safe.
+	routingDoc := *doc
 	if len(doc.Servers) > 0 {
 		modifiedServers := make(openapi3.Servers, 0, len(doc.Servers))
 		for _, server := range doc.Servers {
@@ -225,15 +226,11 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 				modifiedServers = append(modifiedServers, server)
 			}
 		}
-		doc.Servers = modifiedServers
+		routingDoc.Servers = modifiedServers
 	}
 
-	// Create router
-	router, err := gorillamux.NewRouter(doc)
-
-	// Restore original servers
-	doc.Servers = originalServers
-
+	// Create router from the clone (original doc is never mutated)
+	router, err := gorillamux.NewRouter(&routingDoc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
@@ -274,6 +271,108 @@ func (v *Validator) validateInteraction(doc *openapi3.T, interaction *Interactio
 	}
 
 	if err := openapi3filter.ValidateResponse(ctx, responseValidationInput); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, err.Error())
+		return &result, nil
+	}
+
+	return &result, nil
+}
+
+// ValidateRequest validates only the HTTP request (no response) against a registered schema.
+// This is useful for mock servers that need to validate incoming requests without a response.
+func (v *Validator) ValidateRequest(schemaID, method, path string, headers map[string]string, body string) (*ValidationResult, error) {
+	v.mu.RLock()
+	doc, ok := v.schemas[schemaID]
+	v.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("schema not found: %s", schemaID)
+	}
+
+	var result ValidationResult
+	result.Valid = true
+
+	// Handle basePath from Swagger 2.0 schemas
+	requestPath := path
+	if len(doc.Servers) > 0 {
+		for _, server := range doc.Servers {
+			if serverURL, err := url.Parse(server.URL); err == nil && serverURL.Path != "" && serverURL.Path != "/" {
+				basePath := strings.TrimSuffix(serverURL.Path, "/")
+				if strings.HasPrefix(requestPath, basePath+"/") {
+					requestPath = strings.TrimPrefix(requestPath, basePath)
+					break
+				}
+			}
+		}
+	}
+
+	// Create HTTP request
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	baseURL := "http://localhost"
+	if len(doc.Servers) > 0 {
+		if serverURL, err := url.Parse(doc.Servers[0].URL); err == nil {
+			baseURL = fmt.Sprintf("%s://%s", serverURL.Scheme, serverURL.Host)
+		}
+	}
+
+	httpReq, err := http.NewRequest(method, baseURL+requestPath, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	for k, val := range headers {
+		httpReq.Header.Set(k, val)
+	}
+
+	// Create a shallow clone of the doc with stripped server URLs for routing.
+	routingDoc := *doc
+	if len(doc.Servers) > 0 {
+		modifiedServers := make(openapi3.Servers, 0, len(doc.Servers))
+		for _, server := range doc.Servers {
+			if serverURL, err := url.Parse(server.URL); err == nil {
+				serverURL.Path = ""
+				serverURL.RawPath = ""
+				newServer := &openapi3.Server{
+					URL:         serverURL.String(),
+					Description: server.Description,
+					Variables:   server.Variables,
+				}
+				modifiedServers = append(modifiedServers, newServer)
+			} else {
+				modifiedServers = append(modifiedServers, server)
+			}
+		}
+		routingDoc.Servers = modifiedServers
+	}
+
+	// Create router from the clone (original doc is never mutated)
+	router, err := gorillamux.NewRouter(&routingDoc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create router: %w", err)
+	}
+
+	// Find route
+	route, pathParams, err := router.FindRoute(httpReq)
+	if err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, fmt.Sprintf("route not found: %v", err))
+		return &result, nil
+	}
+
+	// Validate request only (no response validation)
+	ctx := context.Background()
+	requestValidationInput := &openapi3filter.RequestValidationInput{
+		Request:    httpReq,
+		PathParams: pathParams,
+		Route:      route,
+	}
+
+	if err := openapi3filter.ValidateRequest(ctx, requestValidationInput); err != nil {
 		result.Valid = false
 		result.Errors = append(result.Errors, err.Error())
 		return &result, nil

--- a/pkg/cvt/validator_test.go
+++ b/pkg/cvt/validator_test.go
@@ -263,3 +263,64 @@ func TestGetSchema(t *testing.T) {
 		t.Fatal("expected not to find nonexistent schema")
 	}
 }
+
+func TestValidateRequest_Valid(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	result, err := v.ValidateRequest("test", "GET", "/pets", nil, "")
+	if err != nil {
+		t.Fatalf("ValidateRequest failed: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid request, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateRequest_InvalidBody(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	headers := map[string]string{"Content-Type": "application/json"}
+	// POST /pets requires name field
+	result, err := v.ValidateRequest("test", "POST", "/pets", headers, `{"invalid": true}`)
+	if err != nil {
+		t.Fatalf("ValidateRequest failed: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected invalid request for missing required fields")
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected validation errors")
+	}
+}
+
+func TestValidateRequest_RouteNotFound(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	result, err := v.ValidateRequest("test", "GET", "/nonexistent", nil, "")
+	if err != nil {
+		t.Fatalf("ValidateRequest failed: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected invalid result for non-existent route")
+	}
+}
+
+func TestValidateRequest_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	_, err := v.ValidateRequest("nonexistent", "GET", "/test", nil, "")
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}

--- a/pkg/mock/cors.go
+++ b/pkg/mock/cors.go
@@ -1,0 +1,20 @@
+package mock
+
+import "net/http"
+
+// CORSMiddleware adds CORS headers to all responses and handles OPTIONS preflight.
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/mock/cors_test.go
+++ b/pkg/mock/cors_test.go
@@ -1,0 +1,50 @@
+package mock
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORS_PreflightOptions(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called for OPTIONS preflight")
+	})
+
+	handler := CORSMiddleware(inner)
+	req := httptest.NewRequest("OPTIONS", "/users", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("expected Access-Control-Allow-Origin: *")
+	}
+	if w.Header().Get("Access-Control-Allow-Methods") == "" {
+		t.Error("expected Access-Control-Allow-Methods header")
+	}
+}
+
+func TestCORS_RegularRequest(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(200)
+	})
+
+	handler := CORSMiddleware(inner)
+	req := httptest.NewRequest("GET", "/users", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("inner handler was not called")
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("expected CORS headers on regular request")
+	}
+}

--- a/pkg/mock/handler.go
+++ b/pkg/mock/handler.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -292,28 +291,17 @@ func getFirstContentType(op *openapi3.Operation, statusCode int) string {
 	return ""
 }
 
-// stripServerBasePaths returns a shallow copy of the doc with server URL paths removed.
-// This ensures routes match without the base path prefix (e.g., /pets instead of /api/v3/pets).
+// stripServerBasePaths returns a shallow copy of the doc with Servers set to nil.
+// gorillamux matches requests against server URLs (including hostname), so a schema
+// with servers: [{url: "https://petstore.io/api/v3"}] would require requests to
+// https://petstore.io/api/v3/pets. By clearing Servers, gorillamux matches paths only,
+// which is what a mock server needs (incoming requests are to localhost, not the real host).
 func stripServerBasePaths(doc *openapi3.T) *openapi3.T {
 	if len(doc.Servers) == 0 {
 		return doc
 	}
 
 	clone := *doc
-	stripped := make(openapi3.Servers, 0, len(doc.Servers))
-	for _, server := range doc.Servers {
-		if serverURL, err := url.Parse(server.URL); err == nil {
-			serverURL.Path = ""
-			serverURL.RawPath = ""
-			stripped = append(stripped, &openapi3.Server{
-				URL:         serverURL.String(),
-				Description: server.Description,
-				Variables:   server.Variables,
-			})
-		} else {
-			stripped = append(stripped, server)
-		}
-	}
-	clone.Servers = stripped
+	clone.Servers = nil
 	return &clone
 }

--- a/pkg/mock/handler.go
+++ b/pkg/mock/handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -56,7 +57,11 @@ func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		router, err := gorillamux.NewRouter(doc)
+		// Strip server base paths so routes match without the prefix
+		// (e.g., Petstore has servers: [{url: "/api/v3"}], we want /pets not /api/v3/pets)
+		routingDoc := stripServerBasePaths(doc)
+
+		router, err := gorillamux.NewRouter(routingDoc)
 		if err != nil {
 			continue
 		}
@@ -285,4 +290,30 @@ func getFirstContentType(op *openapi3.Operation, statusCode int) string {
 		return contentType
 	}
 	return ""
+}
+
+// stripServerBasePaths returns a shallow copy of the doc with server URL paths removed.
+// This ensures routes match without the base path prefix (e.g., /pets instead of /api/v3/pets).
+func stripServerBasePaths(doc *openapi3.T) *openapi3.T {
+	if len(doc.Servers) == 0 {
+		return doc
+	}
+
+	clone := *doc
+	stripped := make(openapi3.Servers, 0, len(doc.Servers))
+	for _, server := range doc.Servers {
+		if serverURL, err := url.Parse(server.URL); err == nil {
+			serverURL.Path = ""
+			serverURL.RawPath = ""
+			stripped = append(stripped, &openapi3.Server{
+				URL:         serverURL.String(),
+				Description: server.Description,
+				Variables:   server.Variables,
+			})
+		} else {
+			stripped = append(stripped, server)
+		}
+	}
+	clone.Servers = stripped
+	return &clone
 }

--- a/pkg/mock/handler.go
+++ b/pkg/mock/handler.go
@@ -1,0 +1,280 @@
+// Package mock provides an HTTP handler that serves mock responses from OpenAPI schemas.
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/sahina/cvt/pkg/cvt"
+)
+
+// HandlerConfig controls mock handler behavior.
+type HandlerConfig struct {
+	UseExamples      bool
+	ValidateRequests bool
+	LatencyMs        int
+	Quiet            bool
+}
+
+// MockHandler serves mock HTTP responses from OpenAPI schemas.
+type MockHandler struct {
+	validator *cvt.Validator
+	schemaIDs []string // ordered for deterministic multi-schema matching
+	config    HandlerConfig
+}
+
+// NewMockHandler creates a new mock HTTP handler.
+func NewMockHandler(v *cvt.Validator, schemaIDs []string, cfg HandlerConfig) *MockHandler {
+	return &MockHandler{
+		validator: v,
+		schemaIDs: schemaIDs,
+		config:    cfg,
+	}
+}
+
+// ServeHTTP handles incoming HTTP requests by matching them against registered
+// OpenAPI schemas and returning generated mock responses.
+func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	// Apply latency delay if configured
+	if h.config.LatencyMs > 0 {
+		time.Sleep(time.Duration(h.config.LatencyMs) * time.Millisecond)
+	}
+
+	// Try each schema in order for deterministic routing
+	for _, schemaID := range h.schemaIDs {
+		doc, ok := h.validator.GetSchema(schemaID)
+		if !ok {
+			continue
+		}
+
+		router, err := gorillamux.NewRouter(doc)
+		if err != nil {
+			continue
+		}
+
+		route, _, err := router.FindRoute(r)
+		if err != nil {
+			continue
+		}
+
+		// Route matched — handle it
+		h.handleMatchedRoute(w, r, schemaID, doc, route.Operation, start)
+		return
+	}
+
+	// No schema matched
+	h.writeJSON(w, http.StatusNotFound, map[string]interface{}{
+		"error":  "no matching route",
+		"method": r.Method,
+		"path":   r.URL.Path,
+	})
+	h.logRequest(r, http.StatusNotFound, start)
+}
+
+// handleMatchedRoute processes a request that matched a route in a schema.
+func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request, schemaID string, doc *openapi3.T, op *openapi3.Operation, start time.Time) {
+	// Validate request if configured
+	if h.config.ValidateRequests {
+		// Read and restore the body so it can be read again downstream
+		var bodyStr string
+		if r.Body != nil {
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err == nil {
+				bodyStr = string(bodyBytes)
+			}
+			r.Body = io.NopCloser(strings.NewReader(bodyStr))
+		}
+
+		headers := make(map[string]string)
+		for k := range r.Header {
+			headers[k] = r.Header.Get(k)
+		}
+
+		result, err := h.validator.ValidateRequest(schemaID, r.Method, r.URL.Path, headers, bodyStr)
+		if err == nil && !result.Valid {
+			h.writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"error":      "request validation failed",
+				"violations": result.Errors,
+			})
+			h.logRequest(r, http.StatusBadRequest, start)
+			return
+		}
+	}
+
+	// Determine success status code
+	statusCode := selectSuccessStatus(op)
+
+	// Check if operation has JSON response content
+	if !hasJSONResponse(op, statusCode) {
+		contentType := getFirstContentType(op, statusCode)
+		h.writeJSON(w, http.StatusNotAcceptable, map[string]interface{}{
+			"error":       "mock server only supports application/json responses",
+			"method":      r.Method,
+			"path":        r.URL.Path,
+			"contentType": contentType,
+		})
+		h.logRequest(r, http.StatusNotAcceptable, start)
+		return
+	}
+
+	// Resolve the template path from the operation back to the OpenAPI path pattern
+	templatePath := h.findTemplatePath(doc, r.Method, op)
+
+	// Generate the response
+	opts := cvt.GenerateOptions{
+		UseExamples: h.config.UseExamples,
+		ContentType: "application/json",
+	}
+	resp, err := h.validator.GenerateResponse(schemaID, r.Method, templatePath, opts)
+	if err != nil {
+		h.writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"error":   "response generation failed",
+			"details": err.Error(),
+		})
+		h.logRequest(r, http.StatusInternalServerError, start)
+		return
+	}
+
+	// Write the generated response
+	w.Header().Set("Content-Type", "application/json")
+	for k, v := range resp.Headers {
+		if !strings.EqualFold(k, "Content-Type") {
+			w.Header().Set(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if resp.Body != nil {
+		data, err := json.Marshal(resp.Body)
+		if err != nil {
+			// Already wrote status, best effort
+			h.logRequest(r, resp.StatusCode, start)
+			return
+		}
+		_, _ = w.Write(data)
+	}
+
+	h.logRequest(r, resp.StatusCode, start)
+}
+
+// findTemplatePath finds the OpenAPI template path (e.g. /users/{id}) for an operation.
+func (h *MockHandler) findTemplatePath(doc *openapi3.T, method string, op *openapi3.Operation) string {
+	if doc.Paths == nil {
+		return ""
+	}
+	for path, pathItem := range doc.Paths.Map() {
+		if pathItem.GetOperation(method) == op {
+			return path
+		}
+	}
+	return ""
+}
+
+// RecoverMiddleware wraps an http.Handler with panic recovery that returns 500 JSON.
+func (h *MockHandler) RecoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				h.writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+					"error": "internal server error",
+				})
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// writeJSON writes a JSON response with the given status code.
+func (h *MockHandler) writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	data, err := json.Marshal(body)
+	if err != nil {
+		return
+	}
+	_, _ = w.Write(data)
+}
+
+// logRequest logs a request if not in quiet mode.
+func (h *MockHandler) logRequest(r *http.Request, status int, start time.Time) {
+	if h.config.Quiet {
+		return
+	}
+	elapsed := time.Since(start)
+	log.Printf("[mock] %s %s -> %d (%dms)", r.Method, r.URL.Path, status, elapsed.Milliseconds())
+}
+
+// selectSuccessStatus returns the first 2XX status code from the operation, preferring
+// 200, 201, 202, 204 in that order.
+func selectSuccessStatus(op *openapi3.Operation) int {
+	if op.Responses == nil {
+		return 200
+	}
+
+	preferred := []int{200, 201, 202, 204}
+	for _, code := range preferred {
+		if op.Responses.Status(code) != nil {
+			return code
+		}
+	}
+
+	// Check for any 2XX status
+	for code := range op.Responses.Map() {
+		if strings.HasPrefix(code, "2") {
+			var statusCode int
+			_, _ = fmt.Sscanf(code, "%d", &statusCode)
+			if statusCode > 0 {
+				return statusCode
+			}
+		}
+	}
+
+	return 200
+}
+
+// hasJSONResponse checks if the operation has a JSON response content type for the
+// given status code.
+func hasJSONResponse(op *openapi3.Operation, statusCode int) bool {
+	if op.Responses == nil {
+		return false
+	}
+
+	resp := op.Responses.Status(statusCode)
+	if resp == nil || resp.Value == nil || resp.Value.Content == nil {
+		return false
+	}
+
+	for contentType := range resp.Value.Content {
+		if strings.Contains(contentType, "json") {
+			return true
+		}
+	}
+	return false
+}
+
+// getFirstContentType returns the first content type defined for a response status code,
+// used in error messages when the content type is not supported.
+func getFirstContentType(op *openapi3.Operation, statusCode int) string {
+	if op.Responses == nil {
+		return ""
+	}
+
+	resp := op.Responses.Status(statusCode)
+	if resp == nil || resp.Value == nil || resp.Value.Content == nil {
+		return ""
+	}
+
+	for contentType := range resp.Value.Content {
+		return contentType
+	}
+	return ""
+}

--- a/pkg/mock/handler.go
+++ b/pkg/mock/handler.go
@@ -100,7 +100,15 @@ func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request,
 		}
 
 		result, err := h.validator.ValidateRequest(schemaID, r.Method, r.URL.Path, headers, bodyStr)
-		if err == nil && !result.Valid {
+		if err != nil {
+			h.writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+				"error":   "request validation error",
+				"details": err.Error(),
+			})
+			h.logRequest(r, http.StatusInternalServerError, start)
+			return
+		}
+		if !result.Valid {
 			h.writeJSON(w, http.StatusBadRequest, map[string]interface{}{
 				"error":      "request validation failed",
 				"violations": result.Errors,

--- a/pkg/mock/handler.go
+++ b/pkg/mock/handler.go
@@ -70,8 +70,8 @@ func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		// Route matched — handle it
-		h.handleMatchedRoute(w, r, schemaID, doc, route.Operation, start)
+		// Route matched — handle it (use route.Path for the template path)
+		h.handleMatchedRoute(w, r, schemaID, route.Operation, route.Path, start)
 		return
 	}
 
@@ -85,7 +85,7 @@ func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleMatchedRoute processes a request that matched a route in a schema.
-func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request, schemaID string, doc *openapi3.T, op *openapi3.Operation, start time.Time) {
+func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request, schemaID string, op *openapi3.Operation, templatePath string, start time.Time) {
 	// Validate request if configured
 	if h.config.ValidateRequests {
 		// Read and restore the body so it can be read again downstream
@@ -103,7 +103,13 @@ func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request,
 			headers[k] = r.Header.Get(k)
 		}
 
-		result, err := h.validator.ValidateRequest(schemaID, r.Method, r.URL.Path, headers, bodyStr)
+		// Include query string so required query params are validated
+		requestURI := r.URL.Path
+		if r.URL.RawQuery != "" {
+			requestURI = r.URL.Path + "?" + r.URL.RawQuery
+		}
+
+		result, err := h.validator.ValidateRequest(schemaID, r.Method, requestURI, headers, bodyStr)
 		if err != nil {
 			h.writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
 				"error":   "request validation error",
@@ -125,8 +131,8 @@ func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request,
 	// Determine success status code
 	statusCode := selectSuccessStatus(op)
 
-	// Check if operation has JSON response content
-	if !hasJSONResponse(op, statusCode) {
+	// Allow 204 No Content and other bodyless responses through without JSON check
+	if statusCode != http.StatusNoContent && !hasJSONResponse(op, statusCode) {
 		contentType := getFirstContentType(op, statusCode)
 		h.writeJSON(w, http.StatusNotAcceptable, map[string]interface{}{
 			"error":       "mock server only supports application/json responses",
@@ -138,8 +144,12 @@ func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Resolve the template path from the operation back to the OpenAPI path pattern
-	templatePath := h.findTemplatePath(doc, r.Method, op)
+	// For 204 No Content, return empty response
+	if statusCode == http.StatusNoContent {
+		w.WriteHeader(statusCode)
+		h.logRequest(r, statusCode, start)
+		return
+	}
 
 	// Generate the response
 	opts := cvt.GenerateOptions{
@@ -176,19 +186,6 @@ func (h *MockHandler) handleMatchedRoute(w http.ResponseWriter, r *http.Request,
 	}
 
 	h.logRequest(r, resp.StatusCode, start)
-}
-
-// findTemplatePath finds the OpenAPI template path (e.g. /users/{id}) for an operation.
-func (h *MockHandler) findTemplatePath(doc *openapi3.T, method string, op *openapi3.Operation) string {
-	if doc.Paths == nil {
-		return ""
-	}
-	for path, pathItem := range doc.Paths.Map() {
-		if pathItem.GetOperation(method) == op {
-			return path
-		}
-	}
-	return ""
 }
 
 // RecoverMiddleware wraps an http.Handler with panic recovery that returns 500 JSON.

--- a/pkg/mock/handler_test.go
+++ b/pkg/mock/handler_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/sahina/cvt/pkg/cvt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -290,6 +292,246 @@ func TestHandler_PanicRecovery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "internal server error", body["error"])
 }
+
+func TestSelectSuccessStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       *openapi3.Operation
+		expected int
+	}{
+		{
+			name:     "nil responses returns 200",
+			op:       &openapi3.Operation{Responses: nil},
+			expected: 200,
+		},
+		{
+			name: "only 201 defined returns 201",
+			op: &openapi3.Operation{
+				Responses: &openapi3.Responses{
+					Extensions: map[string]interface{}{},
+				},
+			},
+			expected: 201,
+		},
+		{
+			name: "only 202 defined returns 202",
+			op: &openapi3.Operation{
+				Responses: &openapi3.Responses{
+					Extensions: map[string]interface{}{},
+				},
+			},
+			expected: 202,
+		},
+		{
+			name: "only 204 defined returns 204",
+			op: &openapi3.Operation{
+				Responses: &openapi3.Responses{
+					Extensions: map[string]interface{}{},
+				},
+			},
+			expected: 204,
+		},
+		{
+			name: "non-standard 2XX (206) returns 206",
+			op: &openapi3.Operation{
+				Responses: &openapi3.Responses{
+					Extensions: map[string]interface{}{},
+				},
+			},
+			expected: 206,
+		},
+		{
+			name: "no 2XX codes returns 200",
+			op: &openapi3.Operation{
+				Responses: &openapi3.Responses{
+					Extensions: map[string]interface{}{},
+				},
+			},
+			expected: 200,
+		},
+	}
+
+	// Set up responses for each test case
+	// Case: only 201
+	tests[1].op.Responses.Set("201", &openapi3.ResponseRef{Value: &openapi3.Response{Description: ptr("Created")}})
+	// Case: only 202
+	tests[2].op.Responses.Set("202", &openapi3.ResponseRef{Value: &openapi3.Response{Description: ptr("Accepted")}})
+	// Case: only 204
+	tests[3].op.Responses.Set("204", &openapi3.ResponseRef{Value: &openapi3.Response{Description: ptr("No Content")}})
+	// Case: non-standard 206
+	tests[4].op.Responses.Set("206", &openapi3.ResponseRef{Value: &openapi3.Response{Description: ptr("Partial Content")}})
+	// Case: no 2XX codes (only 400)
+	tests[5].op.Responses.Set("400", &openapi3.ResponseRef{Value: &openapi3.Response{Description: ptr("Bad Request")}})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectSuccessStatus(tt.op)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestHasJSONResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       *openapi3.Operation
+		status   int
+		expected bool
+	}{
+		{
+			name:     "nil responses returns false",
+			op:       &openapi3.Operation{Responses: nil},
+			status:   200,
+			expected: false,
+		},
+		{
+			name: "nil content returns false",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("OK"),
+					Content:     nil,
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: false,
+		},
+		{
+			name: "xml only returns false",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("OK"),
+					Content: openapi3.Content{
+						"application/xml": &openapi3.MediaType{},
+					},
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: false,
+		},
+		{
+			name: "json present returns true",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("OK"),
+					Content: openapi3.Content{
+						"application/json": &openapi3.MediaType{},
+					},
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: true,
+		},
+		{
+			name: "status not found returns false",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("201", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("Created"),
+					Content: openapi3.Content{
+						"application/json": &openapi3.MediaType{},
+					},
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasJSONResponse(tt.op, tt.status)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetFirstContentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       *openapi3.Operation
+		status   int
+		expected string
+	}{
+		{
+			name:     "nil responses returns empty",
+			op:       &openapi3.Operation{Responses: nil},
+			status:   200,
+			expected: "",
+		},
+		{
+			name: "nil content returns empty",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("OK"),
+					Content:     nil,
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: "",
+		},
+		{
+			name: "returns first content type",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("OK"),
+					Content: openapi3.Content{
+						"application/xml": &openapi3.MediaType{},
+					},
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: "application/xml",
+		},
+		{
+			name: "status not found returns empty",
+			op: func() *openapi3.Operation {
+				op := &openapi3.Operation{Responses: &openapi3.Responses{Extensions: map[string]interface{}{}}}
+				op.Responses.Set("201", &openapi3.ResponseRef{Value: &openapi3.Response{
+					Description: ptr("Created"),
+					Content: openapi3.Content{
+						"application/json": &openapi3.MediaType{},
+					},
+				}})
+				return op
+			}(),
+			status:   200,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getFirstContentType(tt.op, tt.status)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestLogRequest_NotQuiet(t *testing.T) {
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("test-api", []byte(testSchema))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"test-api"}, HandlerConfig{Quiet: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	// Should not panic when quiet=false
+	h.logRequest(req, http.StatusOK, time.Now())
+}
+
+// ptr is a helper to create a pointer to a string.
+func ptr(s string) *string { return &s }
 
 func TestHandler_MultiSchema(t *testing.T) {
 	v := cvt.NewValidator()

--- a/pkg/mock/handler_test.go
+++ b/pkg/mock/handler_test.go
@@ -145,6 +145,64 @@ const testSchema2 = `{
   }
 }`
 
+// testSchemaWithBasePath has a server URL with a path prefix, like Petstore's /api/v3.
+// Routes should match WITHOUT the prefix (e.g., /items, not /api/v2/items).
+const testSchemaWithBasePath = `{
+  "openapi": "3.0.0",
+  "info": {"title": "API with BasePath", "version": "1.0.0"},
+  "servers": [
+    {"url": "https://example.com/api/v2"}
+  ],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {"type": "integer"},
+                      "name": {"type": "string"}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
 func newTestHandler(t *testing.T) *MockHandler {
 	t.Helper()
 	v := cvt.NewValidator()
@@ -564,4 +622,90 @@ func TestHandler_MultiSchema(t *testing.T) {
 	err = json.Unmarshal(w.Body.Bytes(), &body)
 	require.NoError(t, err)
 	assert.Equal(t, "no matching route", body["error"])
+}
+
+func TestHandler_SchemaWithServerBasePath(t *testing.T) {
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("basepath-api", []byte(testSchemaWithBasePath))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"basepath-api"}, HandlerConfig{Quiet: true})
+
+	// Routes should match WITHOUT the /api/v2 prefix
+	req := httptest.NewRequest(http.MethodGet, "/items", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "GET /items should match (basePath stripped)")
+
+	var body interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NoError(t, err, "response should be valid JSON")
+
+	// Path params should work too
+	req = httptest.NewRequest(http.MethodGet, "/items/42", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "GET /items/42 should match (basePath stripped)")
+
+	// The full prefixed path should NOT match (we strip it)
+	req = httptest.NewRequest(http.MethodGet, "/api/v2/items", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, "/api/v2/items should 404 (prefix is stripped)")
+}
+
+func TestHandler_MultiSchemaWithBasePath(t *testing.T) {
+	v := cvt.NewValidator()
+	// Schema 1: no server URL
+	err := v.RegisterSchema("no-base", []byte(testSchema))
+	require.NoError(t, err)
+	// Schema 2: has server URL with /api/v2 prefix
+	err = v.RegisterSchema("with-base", []byte(testSchemaWithBasePath))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"no-base", "with-base"}, HandlerConfig{Quiet: true})
+
+	// /users from schema 1 (no base path)
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "GET /users should match schema 1")
+
+	// /items from schema 2 (base path stripped)
+	req = httptest.NewRequest(http.MethodGet, "/items", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "GET /items should match schema 2 (basePath stripped)")
+}
+
+func TestStripServerBasePaths(t *testing.T) {
+	t.Run("no servers returns same doc", func(t *testing.T) {
+		doc := &openapi3.T{OpenAPI: "3.0.0"}
+		result := stripServerBasePaths(doc)
+		assert.Equal(t, doc, result, "should return same pointer when no servers")
+	})
+
+	t.Run("clears servers when present", func(t *testing.T) {
+		doc := &openapi3.T{
+			OpenAPI: "3.0.0",
+			Servers: openapi3.Servers{
+				{URL: "https://api.example.com/v1/api"},
+			},
+		}
+		result := stripServerBasePaths(doc)
+		assert.NotEqual(t, doc, result, "should return new doc")
+		assert.Nil(t, result.Servers, "servers should be nil after stripping")
+	})
+
+	t.Run("does not mutate original doc", func(t *testing.T) {
+		doc := &openapi3.T{
+			OpenAPI: "3.0.0",
+			Servers: openapi3.Servers{
+				{URL: "https://api.example.com/v1"},
+			},
+		}
+		_ = stripServerBasePaths(doc)
+		assert.Len(t, doc.Servers, 1, "original doc should not be mutated")
+		assert.Equal(t, "https://api.example.com/v1", doc.Servers[0].URL)
+	})
 }

--- a/pkg/mock/handler_test.go
+++ b/pkg/mock/handler_test.go
@@ -1,0 +1,325 @@
+package mock
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sahina/cvt/pkg/cvt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSchema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Test API", "version": "1.0.0"},
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {"type": "integer"},
+                      "name": {"type": "string"}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createUser",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "getUser",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/xml-endpoint": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/xml": {
+                "schema": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+const testSchema2 = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Orders API", "version": "1.0.0"},
+  "paths": {
+    "/orders": {
+      "get": {
+        "operationId": "listOrders",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {"type": "integer"},
+                      "total": {"type": "number"}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+func newTestHandler(t *testing.T) *MockHandler {
+	t.Helper()
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("test-api", []byte(testSchema))
+	require.NoError(t, err)
+	return NewMockHandler(v, []string{"test-api"}, HandlerConfig{Quiet: true})
+}
+
+func TestHandler_HappyPath(t *testing.T) {
+	h := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NoError(t, err, "response body should be valid JSON")
+}
+
+func TestHandler_ConcretePathParam(t *testing.T) {
+	h := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/42", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NoError(t, err, "response body should be valid JSON")
+}
+
+func TestHandler_NotFound(t *testing.T) {
+	h := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "no matching route", body["error"])
+	assert.Equal(t, "GET", body["method"])
+	assert.Equal(t, "/nonexistent", body["path"])
+}
+
+func TestHandler_NonJSONContentType(t *testing.T) {
+	h := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/xml-endpoint", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotAcceptable, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "mock server only supports application/json responses", body["error"])
+	assert.Equal(t, "GET", body["method"])
+	assert.Equal(t, "/xml-endpoint", body["path"])
+	assert.Contains(t, body["contentType"].(string), "xml")
+}
+
+func TestHandler_ValidateRequests_Valid(t *testing.T) {
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("test-api", []byte(testSchema))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"test-api"}, HandlerConfig{
+		ValidateRequests: true,
+		Quiet:            true,
+	})
+
+	body := `{"name": "Alice"}`
+	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+}
+
+func TestHandler_ValidateRequests_Invalid(t *testing.T) {
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("test-api", []byte(testSchema))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"test-api"}, HandlerConfig{
+		ValidateRequests: true,
+		Quiet:            true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "request validation failed", body["error"])
+	assert.NotNil(t, body["violations"])
+}
+
+func TestHandler_PanicRecovery(t *testing.T) {
+	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	h := newTestHandler(t)
+	recovered := h.RecoverMiddleware(panicHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	w := httptest.NewRecorder()
+
+	recovered.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "internal server error", body["error"])
+}
+
+func TestHandler_MultiSchema(t *testing.T) {
+	v := cvt.NewValidator()
+	err := v.RegisterSchema("test-api", []byte(testSchema))
+	require.NoError(t, err)
+	err = v.RegisterSchema("orders-api", []byte(testSchema2))
+	require.NoError(t, err)
+
+	h := NewMockHandler(v, []string{"test-api", "orders-api"}, HandlerConfig{Quiet: true})
+
+	// Test route from first schema
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Test route from second schema
+	req = httptest.NewRequest(http.MethodGet, "/orders", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Test unknown route returns 404
+	req = httptest.NewRequest(http.MethodGet, "/unknown", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "no matching route", body["error"])
+}

--- a/pkg/mock/index.go
+++ b/pkg/mock/index.go
@@ -104,6 +104,6 @@ func IndexHandler(v *cvt.Validator, schemaIDs []string) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		tmpl.Execute(w, map[string]interface{}{"Schemas": schemas})
+		_ = tmpl.Execute(w, map[string]interface{}{"Schemas": schemas})
 	})
 }

--- a/pkg/mock/index.go
+++ b/pkg/mock/index.go
@@ -1,0 +1,109 @@
+package mock
+
+import (
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/sahina/cvt/pkg/cvt"
+)
+
+const indexHTML = `<!DOCTYPE html>
+<html>
+<head><title>CVT Mock Server</title>
+<style>
+body { font-family: -apple-system, system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; color: #333; }
+h1 { border-bottom: 2px solid #eee; padding-bottom: 10px; }
+h2 { color: #555; margin-top: 30px; }
+table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #eee; }
+th { background: #f8f8f8; font-weight: 600; }
+.method { font-weight: bold; font-family: monospace; }
+.path { font-family: monospace; }
+.get { color: #2e7d32; } .post { color: #1565c0; } .put { color: #e65100; }
+.patch { color: #6a1b9a; } .delete { color: #c62828; }
+.empty { color: #999; font-style: italic; padding: 20px 0; }
+</style></head>
+<body>
+<h1>CVT Mock Server</h1>
+{{range .Schemas}}
+<h2>{{.Name}}{{if .Version}} ({{.Version}}){{end}}</h2>
+{{if .Endpoints}}
+<table>
+<tr><th>Method</th><th>Path</th><th>Summary</th></tr>
+{{range .Endpoints}}<tr>
+<td class="method {{.MethodLower}}">{{.Method}}</td>
+<td class="path">{{.Path}}</td>
+<td>{{.Summary}}</td>
+</tr>{{end}}
+</table>
+{{else}}
+<p class="empty">No endpoints defined</p>
+{{end}}
+{{end}}
+</body></html>`
+
+type schemaInfo struct {
+	Name      string
+	Version   string
+	Endpoints []endpointInfo
+}
+
+type endpointInfo struct {
+	Method      string
+	MethodLower string
+	Path        string
+	Summary     string
+}
+
+// IndexHandler returns an http.Handler that renders the endpoint index page.
+func IndexHandler(v *cvt.Validator, schemaIDs []string) http.Handler {
+	tmpl := template.Must(template.New("index").Parse(indexHTML))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var schemas []schemaInfo
+
+		for _, id := range schemaIDs {
+			doc, ok := v.GetSchema(id)
+			if !ok {
+				continue
+			}
+
+			info := schemaInfo{Name: id}
+			if doc.Info != nil {
+				info.Version = doc.Info.Version
+			}
+
+			if doc.Paths != nil {
+				for path, pathItem := range doc.Paths.Map() {
+					for method, op := range pathItem.Operations() {
+						ep := endpointInfo{
+							Method:      method,
+							MethodLower: strings.ToLower(method),
+							Path:        path,
+						}
+						if op.Summary != "" {
+							ep.Summary = op.Summary
+						} else if op.OperationID != "" {
+							ep.Summary = op.OperationID
+						}
+						info.Endpoints = append(info.Endpoints, ep)
+					}
+				}
+			}
+
+			sort.Slice(info.Endpoints, func(i, j int) bool {
+				if info.Endpoints[i].Path == info.Endpoints[j].Path {
+					return info.Endpoints[i].Method < info.Endpoints[j].Method
+				}
+				return info.Endpoints[i].Path < info.Endpoints[j].Path
+			})
+
+			schemas = append(schemas, info)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		tmpl.Execute(w, map[string]interface{}{"Schemas": schemas})
+	})
+}

--- a/pkg/mock/index_test.go
+++ b/pkg/mock/index_test.go
@@ -1,0 +1,57 @@
+package mock
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sahina/cvt/pkg/cvt"
+)
+
+func TestIndexPage_WithEndpoints(t *testing.T) {
+	v := cvt.NewValidator()
+	if err := v.RegisterSchema("test", []byte(testSchema)); err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	handler := IndexHandler(v, []string{"test"})
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "CVT Mock Server") {
+		t.Error("expected page title")
+	}
+	if !strings.Contains(body, "/users") {
+		t.Error("expected /users endpoint listed")
+	}
+	if !strings.Contains(body, "GET") {
+		t.Error("expected GET method listed")
+	}
+}
+
+func TestIndexPage_NoEndpoints(t *testing.T) {
+	v := cvt.NewValidator()
+	emptySchema := `{"openapi":"3.0.0","info":{"title":"Empty","version":"1.0.0"},"paths":{}}`
+	if err := v.RegisterSchema("empty", []byte(emptySchema)); err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	handler := IndexHandler(v, []string{"empty"})
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "No endpoints") {
+		t.Error("expected 'No endpoints' message for empty schema")
+	}
+}

--- a/pkg/mock/server.go
+++ b/pkg/mock/server.go
@@ -97,7 +97,7 @@ func (s *Server) Start() error {
 	// Listen on port
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("port %d already in use", s.config.Port)
+		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
 
 	if !s.config.Quiet {
@@ -140,9 +140,15 @@ func (s *Server) Start() error {
 func (s *Server) loadSchemas(paths []string) (*cvt.Validator, []string, error) {
 	v := cvt.NewValidator()
 	var schemaIDs []string
+	usedIDs := make(map[string]int) // track count per base ID for disambiguation
 
 	for _, path := range paths {
-		id := schemaIDFromPath(path)
+		baseID := schemaIDFromPath(path)
+		usedIDs[baseID]++
+		id := baseID
+		if usedIDs[baseID] > 1 {
+			id = fmt.Sprintf("%s-%d", baseID, usedIDs[baseID])
+		}
 		if err := v.RegisterSchemaFromPath(id, path); err != nil {
 			return nil, nil, fmt.Errorf("failed to load schema %s: %w", path, err)
 		}

--- a/pkg/mock/server.go
+++ b/pkg/mock/server.go
@@ -172,7 +172,7 @@ func (s *Server) buildHandler(v *cvt.Validator, schemaIDs []string) http.Handler
 		mockHandler.ServeHTTP(w, r)
 	}))
 
-	return CORSMiddleware(mux)
+	return CORSMiddleware(mockHandler.RecoverMiddleware(mux))
 }
 
 func (s *Server) printBanner(v *cvt.Validator, schemaIDs []string) {

--- a/pkg/mock/server.go
+++ b/pkg/mock/server.go
@@ -1,0 +1,232 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/sahina/cvt/pkg/cvt"
+)
+
+// ServerConfig holds configuration for the mock server.
+type ServerConfig struct {
+	Host             string
+	Port             int
+	SchemaFiles      []string // file paths or URLs
+	Watch            bool
+	ValidateRequests bool
+	UseExamples      bool
+	LatencyMs        int
+	Quiet            bool
+}
+
+// Server is a mock HTTP server that generates responses from OpenAPI schemas.
+type Server struct {
+	config  ServerConfig
+	handler atomic.Pointer[http.Handler]
+	httpSrv *http.Server
+}
+
+// NewServer creates a new mock server with the given configuration.
+func NewServer(cfg ServerConfig) *Server {
+	return &Server{config: cfg}
+}
+
+// Start loads schemas, starts the HTTP server, and blocks until shutdown.
+func (s *Server) Start() error {
+	v, schemaIDs, err := s.loadSchemas(s.config.SchemaFiles)
+	if err != nil {
+		return err
+	}
+
+	s.printBanner(v, schemaIDs)
+
+	handler := s.buildHandler(v, schemaIDs)
+	s.handler.Store(&handler)
+
+	// Delegating handler reads from atomic pointer (supports hot-reload)
+	delegator := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := *s.handler.Load()
+		h.ServeHTTP(w, r)
+	})
+
+	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	s.httpSrv = &http.Server{
+		Addr:         addr,
+		Handler:      delegator,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Start watcher if enabled
+	if s.config.Watch {
+		filePaths := filterFilePaths(s.config.SchemaFiles)
+		if len(filePaths) > 0 {
+			w, err := NewWatcher(filePaths, func() {
+				newV, newIDs, loadErr := s.loadSchemas(s.config.SchemaFiles)
+				if loadErr != nil {
+					fmt.Fprintf(os.Stderr, "[mock] WARNING: reload failed: %v (keeping current schemas)\n", loadErr)
+					return
+				}
+				newHandler := s.buildHandler(newV, newIDs)
+				s.handler.Store(&newHandler)
+				if !s.config.Quiet {
+					fmt.Println("[mock] Schemas reloaded successfully")
+				}
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[mock] WARNING: file watch unavailable: %v\n", err)
+			} else {
+				defer w.Close()
+				if !s.config.Quiet {
+					fmt.Println("[mock] Watching for file changes")
+				}
+			}
+		}
+	}
+
+	// Listen on port
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("port %d already in use", s.config.Port)
+	}
+
+	if !s.config.Quiet {
+		fmt.Printf("[mock] Mock server listening on http://%s\n", addr)
+		fmt.Println("[mock] Press Ctrl+C to stop")
+	}
+
+	// Handle shutdown signals
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.httpSrv.Serve(ln)
+	}()
+
+	select {
+	case sig := <-sigCh:
+		if !s.config.Quiet {
+			fmt.Printf("\n[mock] Received %s, shutting down...\n", sig)
+		}
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("server failed: %w", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if shutdownErr := s.httpSrv.Shutdown(ctx); shutdownErr != nil {
+		return fmt.Errorf("shutdown failed: %w", shutdownErr)
+	}
+
+	if !s.config.Quiet {
+		fmt.Println("[mock] Server stopped")
+	}
+	return nil
+}
+
+func (s *Server) loadSchemas(paths []string) (*cvt.Validator, []string, error) {
+	v := cvt.NewValidator()
+	var schemaIDs []string
+
+	for _, path := range paths {
+		id := schemaIDFromPath(path)
+		if err := v.RegisterSchemaFromPath(id, path); err != nil {
+			return nil, nil, fmt.Errorf("failed to load schema %s: %w", path, err)
+		}
+		schemaIDs = append(schemaIDs, id)
+	}
+
+	s.detectOverlaps(v, schemaIDs)
+	return v, schemaIDs, nil
+}
+
+func (s *Server) buildHandler(v *cvt.Validator, schemaIDs []string) http.Handler {
+	mockHandler := NewMockHandler(v, schemaIDs, HandlerConfig{
+		UseExamples:      s.config.UseExamples,
+		ValidateRequests: s.config.ValidateRequests,
+		LatencyMs:        s.config.LatencyMs,
+		Quiet:            s.config.Quiet,
+	})
+
+	indexH := IndexHandler(v, schemaIDs)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" && r.Method == "GET" {
+			indexH.ServeHTTP(w, r)
+			return
+		}
+		mockHandler.ServeHTTP(w, r)
+	}))
+
+	return CORSMiddleware(mux)
+}
+
+func (s *Server) printBanner(v *cvt.Validator, schemaIDs []string) {
+	if s.config.Quiet {
+		return
+	}
+	for _, id := range schemaIDs {
+		endpoints, _ := v.ListEndpoints(id)
+		fmt.Printf("[mock] Loaded schema: %s (%d endpoints)\n", id, len(endpoints))
+	}
+}
+
+func (s *Server) detectOverlaps(v *cvt.Validator, schemaIDs []string) {
+	if s.config.Quiet || len(schemaIDs) < 2 {
+		return
+	}
+	seen := make(map[string]string)
+	for _, id := range schemaIDs {
+		endpoints, err := v.ListEndpoints(id)
+		if err != nil {
+			continue
+		}
+		for _, ep := range endpoints {
+			if prev, exists := seen[ep]; exists {
+				fmt.Printf("[mock] WARNING: %s defined in both %s and %s (using %s)\n", ep, prev, id, prev)
+			} else {
+				seen[ep] = id
+			}
+		}
+	}
+}
+
+func schemaIDFromPath(path string) string {
+	name := filepath.Base(path)
+	ext := filepath.Ext(name)
+	if ext != "" {
+		name = strings.TrimSuffix(name, ext)
+	}
+	if name == "" || name == "." {
+		return "schema"
+	}
+	return name
+}
+
+func filterFilePaths(paths []string) []string {
+	var files []string
+	for _, p := range paths {
+		if !isURL(p) {
+			files = append(files, p)
+		}
+	}
+	return files
+}
+
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}

--- a/pkg/mock/server_test.go
+++ b/pkg/mock/server_test.go
@@ -1,0 +1,132 @@
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func getFreePort() int {
+	l, _ := net.Listen("tcp", "127.0.0.1:0")
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+func TestServer_Integration_BasicMocking(t *testing.T) {
+	// Write testSchema to a temp file
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "api.json")
+	os.WriteFile(schemaPath, []byte(testSchema), 0644)
+
+	port := getFreePort()
+	srv := NewServer(ServerConfig{
+		Host:        "127.0.0.1",
+		Port:        port,
+		SchemaFiles: []string{schemaPath},
+		UseExamples: true,
+		Quiet:       true,
+	})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ready := false
+	for i := 0; i < 50; i++ {
+		resp, err := http.Get(baseURL + "/")
+		if err == nil {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("server did not start in time")
+	}
+
+	// Test: GET /users returns 200 with JSON
+	resp, err := http.Get(baseURL + "/users")
+	if err != nil {
+		t.Fatalf("GET /users failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /users: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var body interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Test: GET /users/42 returns 200
+	resp2, err := http.Get(baseURL + "/users/42")
+	if err != nil {
+		t.Fatalf("GET /users/42 failed: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Errorf("GET /users/42: expected 200, got %d", resp2.StatusCode)
+	}
+
+	// Test: GET /unknown returns 404
+	resp3, err := http.Get(baseURL + "/unknown")
+	if err != nil {
+		t.Fatalf("GET /unknown failed: %v", err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Errorf("GET /unknown: expected 404, got %d", resp3.StatusCode)
+	}
+
+	// Test: GET / returns index page (HTML)
+	resp4, err := http.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET / failed: %v", err)
+	}
+	resp4.Body.Close()
+	if resp4.StatusCode != 200 {
+		t.Errorf("GET /: expected 200, got %d", resp4.StatusCode)
+	}
+	if ct := resp4.Header.Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("GET /: expected text/html, got %s", ct)
+	}
+
+	// Test: CORS headers present
+	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("expected CORS headers on response")
+	}
+
+	// Shutdown
+	srv.httpSrv.Close()
+}
+
+func TestServer_SchemaIDFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"openapi.json", "openapi"},
+		{"/path/to/api.yaml", "api"},
+		{"spec.yml", "spec"},
+		{"https://example.com/openapi.json", "openapi"},
+		{"", "schema"},
+	}
+
+	for _, tt := range tests {
+		got := schemaIDFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("schemaIDFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/mock/server_test.go
+++ b/pkg/mock/server_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/sahina/cvt/pkg/cvt"
 )
 
 func getFreePort() int {
@@ -109,6 +111,155 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 
 	// Shutdown
 	srv.httpSrv.Close()
+}
+
+func TestFilterFilePaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "mix of files and URLs",
+			input: []string{"./openapi.json", "https://example.com/api.json", "/abs/path.yaml", "http://localhost/spec.json"},
+			want:  []string{"./openapi.json", "/abs/path.yaml"},
+		},
+		{
+			name:  "all URLs",
+			input: []string{"https://a.com/x.json", "http://b.com/y.json"},
+			want:  nil,
+		},
+		{
+			name:  "all files",
+			input: []string{"a.json", "b.yaml"},
+			want:  []string{"a.json", "b.yaml"},
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterFilePaths(tt.input)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("filterFilePaths(%v) = %v, want nil", tt.input, got)
+				}
+			} else {
+				if len(got) != len(tt.want) {
+					t.Fatalf("filterFilePaths(%v) = %v, want %v", tt.input, got, tt.want)
+				}
+				for i := range got {
+					if got[i] != tt.want[i] {
+						t.Errorf("filterFilePaths(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"http://example.com/api.json", true},
+		{"https://example.com/api.json", true},
+		{"./openapi.json", false},
+		{"/abs/path.yaml", false},
+		{"openapi.json", false},
+		{"ftp://example.com/file", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isURL(tt.input)
+			if got != tt.want {
+				t.Errorf("isURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectOverlaps(t *testing.T) {
+	// Create two schemas that both define GET /users
+	schema1 := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "API One", "version": "1.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers1",
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {"type": "array", "items": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+	schema2 := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "API Two", "version": "1.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers2",
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {"type": "array", "items": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := cvt.NewValidator()
+	if err := v.RegisterSchema("api-one", []byte(schema1)); err != nil {
+		t.Fatalf("register schema1: %v", err)
+	}
+	if err := v.RegisterSchema("api-two", []byte(schema2)); err != nil {
+		t.Fatalf("register schema2: %v", err)
+	}
+
+	// Test with quiet=false to exercise the overlap warning branch
+	srv := NewServer(ServerConfig{Quiet: false})
+	// Should not panic
+	srv.detectOverlaps(v, []string{"api-one", "api-two"})
+
+	// Test with quiet=true (early return)
+	srvQuiet := NewServer(ServerConfig{Quiet: true})
+	srvQuiet.detectOverlaps(v, []string{"api-one", "api-two"})
+
+	// Test with single schema (early return on len < 2)
+	srv.detectOverlaps(v, []string{"api-one"})
+}
+
+func TestPrintBanner_NotQuiet(t *testing.T) {
+	v := cvt.NewValidator()
+	if err := v.RegisterSchema("test-api", []byte(testSchema)); err != nil {
+		t.Fatalf("register schema: %v", err)
+	}
+
+	srv := NewServer(ServerConfig{Quiet: false})
+	// Should not panic when quiet=false
+	srv.printBanner(v, []string{"test-api"})
 }
 
 func TestServer_SchemaIDFromPath(t *testing.T) {

--- a/pkg/mock/server_test.go
+++ b/pkg/mock/server_test.go
@@ -14,10 +14,14 @@ import (
 	"github.com/sahina/cvt/pkg/cvt"
 )
 
-func getFreePort() int {
-	l, _ := net.Listen("tcp", "127.0.0.1:0")
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("getFreePort: %v", err)
+	}
 	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	_ = l.Close()
 	return port
 }
 
@@ -25,9 +29,11 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	// Write testSchema to a temp file
 	dir := t.TempDir()
 	schemaPath := filepath.Join(dir, "api.json")
-	os.WriteFile(schemaPath, []byte(testSchema), 0644)
+	if err := os.WriteFile(schemaPath, []byte(testSchema), 0644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
 
-	port := getFreePort()
+	port := getFreePort(t)
 	srv := NewServer(ServerConfig{
 		Host:        "127.0.0.1",
 		Port:        port,
@@ -45,7 +51,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		resp, err := http.Get(baseURL + "/")
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			ready = true
 			break
 		}
@@ -60,7 +66,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /users failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("GET /users: expected 200, got %d: %s", resp.StatusCode, body)
@@ -76,7 +82,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /users/42 failed: %v", err)
 	}
-	resp2.Body.Close()
+	_ = resp2.Body.Close()
 	if resp2.StatusCode != 200 {
 		t.Errorf("GET /users/42: expected 200, got %d", resp2.StatusCode)
 	}
@@ -86,7 +92,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /unknown failed: %v", err)
 	}
-	resp3.Body.Close()
+	_ = resp3.Body.Close()
 	if resp3.StatusCode != 404 {
 		t.Errorf("GET /unknown: expected 404, got %d", resp3.StatusCode)
 	}
@@ -96,7 +102,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET / failed: %v", err)
 	}
-	resp4.Body.Close()
+	_ = resp4.Body.Close()
 	if resp4.StatusCode != 200 {
 		t.Errorf("GET /: expected 200, got %d", resp4.StatusCode)
 	}
@@ -110,7 +116,7 @@ func TestServer_Integration_BasicMocking(t *testing.T) {
 	}
 
 	// Shutdown
-	srv.httpSrv.Close()
+	_ = srv.httpSrv.Close()
 }
 
 func TestFilterFilePaths(t *testing.T) {

--- a/pkg/mock/server_test.go
+++ b/pkg/mock/server_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sahina/cvt/pkg/cvt"
 )
 
+// getFreePort binds port 0 to get an available port, then closes the listener.
+// There is a small TOCTOU window, but it's acceptable for tests.
 func getFreePort(t *testing.T) int {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/mock/watcher.go
+++ b/pkg/mock/watcher.go
@@ -38,7 +38,7 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 		dir := filepath.Dir(absPath)
 		if !watchedDirs[dir] {
 			if err := fw.Add(dir); err != nil {
-				fw.Close()
+				_ = fw.Close()
 				return nil, err
 			}
 			watchedDirs[dir] = true
@@ -102,6 +102,6 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 // Close stops the watcher.
 func (w *Watcher) Close() {
 	close(w.done)
-	w.watcher.Close()
+	_ = w.watcher.Close()
 	w.wg.Wait()
 }

--- a/pkg/mock/watcher.go
+++ b/pkg/mock/watcher.go
@@ -1,0 +1,105 @@
+package mock
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher watches schema files for changes and triggers a reload callback.
+type Watcher struct {
+	watcher *fsnotify.Watcher
+	done    chan struct{}
+	wg      sync.WaitGroup
+}
+
+// NewWatcher creates a file watcher that calls onReload when any watched file changes.
+func NewWatcher(files []string, onReload func()) (*Watcher, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch parent directories (handles vim/emacs atomic writes via RENAME/CREATE)
+	watchedDirs := make(map[string]bool)
+	fileSet := make(map[string]bool)
+
+	for _, f := range files {
+		absPath, err := filepath.Abs(f)
+		if err != nil {
+			absPath = f
+		}
+		fileSet[absPath] = true
+
+		dir := filepath.Dir(absPath)
+		if !watchedDirs[dir] {
+			if err := fw.Add(dir); err != nil {
+				fw.Close()
+				return nil, err
+			}
+			watchedDirs[dir] = true
+		}
+	}
+
+	w := &Watcher{
+		watcher: fw,
+		done:    make(chan struct{}),
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+
+		var debounceTimer *time.Timer
+		var mu sync.Mutex
+
+		for {
+			select {
+			case event, ok := <-fw.Events:
+				if !ok {
+					return
+				}
+
+				absPath, err := filepath.Abs(event.Name)
+				if err != nil {
+					absPath = event.Name
+				}
+
+				if !fileSet[absPath] {
+					continue
+				}
+
+				// React to Write, Create, and Rename (covers vim/emacs atomic writes)
+				if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+					continue
+				}
+
+				mu.Lock()
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				debounceTimer = time.AfterFunc(500*time.Millisecond, onReload)
+				mu.Unlock()
+
+			case _, ok := <-fw.Errors:
+				if !ok {
+					return
+				}
+
+			case <-w.done:
+				return
+			}
+		}
+	}()
+
+	return w, nil
+}
+
+// Close stops the watcher.
+func (w *Watcher) Close() {
+	close(w.done)
+	w.watcher.Close()
+	w.wg.Wait()
+}

--- a/pkg/mock/watcher.go
+++ b/pkg/mock/watcher.go
@@ -15,6 +15,8 @@ type Watcher struct {
 	watcher *fsnotify.Watcher
 	done    chan struct{}
 	wg      sync.WaitGroup
+	mu      sync.Mutex
+	timer   *time.Timer
 }
 
 // NewWatcher creates a file watcher that calls onReload when any watched file changes.
@@ -54,9 +56,6 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 	go func() {
 		defer w.wg.Done()
 
-		var debounceTimer *time.Timer
-		var mu sync.Mutex
-
 		for {
 			select {
 			case event, ok := <-fw.Events:
@@ -78,12 +77,19 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 					continue
 				}
 
-				mu.Lock()
-				if debounceTimer != nil {
-					debounceTimer.Stop()
+				w.mu.Lock()
+				if w.timer != nil {
+					w.timer.Stop()
 				}
-				debounceTimer = time.AfterFunc(debounceInterval, onReload)
-				mu.Unlock()
+				w.timer = time.AfterFunc(debounceInterval, func() {
+					select {
+					case <-w.done:
+						return
+					default:
+						onReload()
+					}
+				})
+				w.mu.Unlock()
 
 			case _, ok := <-fw.Errors:
 				if !ok {
@@ -102,6 +108,11 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 // Close stops the watcher.
 func (w *Watcher) Close() {
 	close(w.done)
+	w.mu.Lock()
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+	w.mu.Unlock()
 	_ = w.watcher.Close()
 	w.wg.Wait()
 }

--- a/pkg/mock/watcher.go
+++ b/pkg/mock/watcher.go
@@ -8,6 +8,8 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+const debounceInterval = 500 * time.Millisecond
+
 // Watcher watches schema files for changes and triggers a reload callback.
 type Watcher struct {
 	watcher *fsnotify.Watcher
@@ -80,7 +82,7 @@ func NewWatcher(files []string, onReload func()) (*Watcher, error) {
 				if debounceTimer != nil {
 					debounceTimer.Stop()
 				}
-				debounceTimer = time.AfterFunc(500*time.Millisecond, onReload)
+				debounceTimer = time.AfterFunc(debounceInterval, onReload)
 				mu.Unlock()
 
 			case _, ok := <-fw.Errors:

--- a/pkg/mock/watcher_test.go
+++ b/pkg/mock/watcher_test.go
@@ -10,7 +10,9 @@ import (
 func TestWatcher_FileChange(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := filepath.Join(dir, "test.json")
-	os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Test","version":"1.0.0"},"paths":{}}`), 0644)
+	if err := os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Test","version":"1.0.0"},"paths":{}}`), 0644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
 
 	reloaded := make(chan struct{}, 1)
 	w, err := NewWatcher([]string{schemaPath}, func() {
@@ -25,7 +27,9 @@ func TestWatcher_FileChange(t *testing.T) {
 	defer w.Close()
 
 	time.Sleep(100 * time.Millisecond)
-	os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Updated","version":"2.0.0"},"paths":{}}`), 0644)
+	if err := os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Updated","version":"2.0.0"},"paths":{}}`), 0644); err != nil {
+		t.Fatalf("write updated schema: %v", err)
+	}
 
 	select {
 	case <-reloaded:
@@ -40,7 +44,9 @@ func TestWatcher_IgnoresUnrelatedFiles(t *testing.T) {
 	schemaPath := filepath.Join(dir, "watched.json")
 	otherPath := filepath.Join(dir, "other.json")
 
-	os.WriteFile(schemaPath, []byte(`{}`), 0644)
+	if err := os.WriteFile(schemaPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
 
 	reloaded := make(chan struct{}, 1)
 	w, err := NewWatcher([]string{schemaPath}, func() {
@@ -55,7 +61,9 @@ func TestWatcher_IgnoresUnrelatedFiles(t *testing.T) {
 	defer w.Close()
 
 	time.Sleep(100 * time.Millisecond)
-	os.WriteFile(otherPath, []byte(`{"other": true}`), 0644)
+	if err := os.WriteFile(otherPath, []byte(`{"other": true}`), 0644); err != nil {
+		t.Fatalf("write other file: %v", err)
+	}
 
 	select {
 	case <-reloaded:

--- a/pkg/mock/watcher_test.go
+++ b/pkg/mock/watcher_test.go
@@ -1,0 +1,66 @@
+package mock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcher_FileChange(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "test.json")
+	os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Test","version":"1.0.0"},"paths":{}}`), 0644)
+
+	reloaded := make(chan struct{}, 1)
+	w, err := NewWatcher([]string{schemaPath}, func() {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer w.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0","info":{"title":"Updated","version":"2.0.0"},"paths":{}}`), 0644)
+
+	select {
+	case <-reloaded:
+		// success
+	case <-time.After(3 * time.Second):
+		t.Error("expected reload callback within 3 seconds")
+	}
+}
+
+func TestWatcher_IgnoresUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "watched.json")
+	otherPath := filepath.Join(dir, "other.json")
+
+	os.WriteFile(schemaPath, []byte(`{}`), 0644)
+
+	reloaded := make(chan struct{}, 1)
+	w, err := NewWatcher([]string{schemaPath}, func() {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer w.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	os.WriteFile(otherPath, []byte(`{"other": true}`), 0644)
+
+	select {
+	case <-reloaded:
+		t.Error("should not reload for unrelated file change")
+	case <-time.After(1 * time.Second):
+		// success
+	}
+}


### PR DESCRIPTION
## Summary

- Add `cvt mock` CLI command that starts an HTTP mock server from OpenAPI schemas, with support for multiple schemas, request validation, hot-reload via `--watch`, latency simulation, and CORS headers
- Implement `pkg/mock/` package with handler, server, route index, file watcher, and CORS middleware
- Enhance `pkg/cvt/` validator and generator to support mock server use cases (route matching, response generation)
- Add comprehensive tests: unit tests for `pkg/mock/` (80%+ coverage), CLI flag tests, and end-to-end integration tests via `make test-e2e`
- Update documentation across CLI reference, README, quick-start guide, consumer testing guide, FAQ, and examples

## Test plan

- [x] `make test` passes (unit tests)
- [x] `make test-e2e` passes (mock server integration tests)
- [x] `cvt mock --schema ./sdks/shared/openapi.json` starts and responds to requests
- [x] Verify docs render correctly on docs-site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `cvt mock` command to start a standalone HTTP mock server from OpenAPI schemas, supporting multiple schemas, request validation (`--validate-requests`), hot-reload watch mode (`--watch`), artificial latency simulation (`--latency`), and CORS headers.

* **Bug Fixes**
  * Fixed potential panic in schema value generation when handling schemas without explicit types.

* **Tests**
  * Added comprehensive end-to-end tests for the mock server CLI command validating routing, validation, and configuration behaviors.

* **Documentation**
  * Updated CLI reference and getting started guides to document the new `cvt mock` command and its options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->