### PR TITLE
test: raise pkg/cvt test coverage to 80%+ (#92)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-cli install-cli test test-docker test-server test-cli test-e2e test-node-sdk test-python-sdk test-go-sdk test-java-sdk test-integration test-cache test-all test-with-observability clean generate generate-python generate-go-sdk generate-java-sdk help
+.PHONY: all build build-cli install-cli test test-docker test-server test-cli test-e2e test-node-sdk test-python-sdk test-go-sdk test-java-sdk test-integration test-cache test-all test-with-observability test-cover clean generate generate-python generate-go-sdk generate-java-sdk help
 .PHONY: up down restart logs status
 .PHONY: install-health-probe health check-health watch-health
 .PHONY: run-server run-example
@@ -37,6 +37,7 @@ help:
 	@echo "  make test-go-sdk        - Run Go SDK tests with coverage"
 	@echo "  make test-java-sdk      - Run Java SDK tests with coverage"
 	@echo "  make test-coverage      - Run tests with coverage report (HTML + summary)"
+	@echo "  make test-cover        - Run pkg/cvt tests with 80%% coverage gate"
 	@echo "  make test-integration   - Run Go server integration tests (requires Docker)"
 	@echo "  make test-cli           - Run CLI unit tests"
 	@echo "  make test-e2e           - Run CLI e2e tests (cvt mock)"
@@ -245,6 +246,32 @@ test-coverage:
 	go tool cover -html=coverage.filtered.out -o coverage.html
 	@echo "📄 Detailed HTML coverage report generated: coverage.html"
 	@echo "✅ Run 'open coverage.html' to view the detailed coverage report"
+
+test-cover:
+	@echo "🧪 Running tests with coverage..."
+	@go test -coverprofile=coverage-pkg.out -covermode=atomic \
+		./pkg/cvt/... ./server/cvtservice/... ./server/storage/... 2>&1 | \
+		grep -v 'server/storage/postgres' | \
+		awk '/^ok/ && /coverage:/ {for(i=1;i<=NF;i++) if($$i=="coverage:") cov=$$(i+1); printf "  %-55s %s\n", $$2, cov} \
+		     /^[^o]/ && /coverage:/ {for(i=1;i<=NF;i++) if($$i=="coverage:") cov=$$(i+1); pkg=$$1; printf "  %-55s %s\n", pkg, cov} \
+		     /^FAIL/ {printf "  %-55s FAIL\n", $$2} \
+		     /^\?/ {printf "  %-55s no tests\n", $$2}'
+	@echo "  (postgres excluded — tested via make test-docker)"
+	@echo ""
+	@grep -v 'server/storage/postgres/' coverage-pkg.out > coverage-pkg-filtered.out
+	@TOTAL_COV=$$(go tool cover -func=coverage-pkg-filtered.out | grep '^total:' | awk '{print $$NF}' | tr -d '%'); \
+	echo "📊 Total coverage: $${TOTAL_COV}%"; \
+	echo ""; \
+	if [ $$(echo "$${TOTAL_COV} < 80.0" | bc -l) -eq 1 ]; then \
+		echo "❌ Coverage $${TOTAL_COV}% is below 80% threshold"; \
+		echo ""; \
+		echo "Functions below 80%:"; \
+		go tool cover -func=coverage-pkg-filtered.out | grep -v '^total:' | awk '$$NF+0 < 80 {print}'; \
+		exit 1; \
+	else \
+		echo "✅ Coverage gate passed ($${TOTAL_COV}% >= 80%)"; \
+	fi
+	@rm -f coverage-pkg-filtered.out
 
 test-integration:
 	@echo "🧪 Running integration tests (requires Docker)..."

--- a/pkg/cvt/compatibility_test.go
+++ b/pkg/cvt/compatibility_test.go
@@ -1,0 +1,617 @@
+package cvt
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Helper to parse an inline OpenAPI v3 schema for compatibility tests.
+func mustParseSchema(t *testing.T, content string) *openapi3.T {
+	t.Helper()
+	v := NewValidator()
+	doc, err := v.parseSchema([]byte(content))
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+	return doc
+}
+
+const compatBaseSchema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Test API", "version": "1.0.0"},
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer", "enum": [10, 20, 50]}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createUser",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"},
+                  "email": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {"description": "Created"}
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "getUser",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteUser",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "204": {"description": "Deleted"}
+        }
+      }
+    }
+  }
+}`
+
+func TestNewCompatibilityEngine(t *testing.T) {
+	e := NewCompatibilityEngine()
+	if e == nil {
+		t.Fatal("expected non-nil engine")
+	}
+}
+
+func TestCompareSchemas_NoChanges(t *testing.T) {
+	doc := mustParseSchema(t, compatBaseSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(doc, doc)
+
+	if !compatible {
+		t.Errorf("expected compatible, got %d breaking changes", len(changes))
+		for _, c := range changes {
+			t.Logf("  %s: %s", c.Type, c.Description)
+		}
+	}
+}
+
+func TestCompareSchemas_EndpointRemoved(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema without DELETE /users/{id}
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when endpoint removed")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeEndpointRemoved && c.Method == "DELETE" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected ENDPOINT_REMOVED for DELETE /users/{id}")
+	}
+}
+
+func TestCompareSchemas_RequiredParameterAdded(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema adds required "sort" parameter to GET /users
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [
+	          {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "enum": [10, 20, 50]}},
+	          {"name": "sort", "in": "query", "required": true, "schema": {"type": "string"}}
+	        ],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "delete": {
+	        "operationId": "deleteUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"204": {"description": "Deleted"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when required parameter added")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeRequiredParameterAdded {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected REQUIRED_PARAMETER_ADDED change")
+	}
+}
+
+func TestCompareSchemas_RequiredFieldAdded(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema adds required "email" field to POST /users request body
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [{"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "enum": [10, 20, 50]}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {
+	            "application/json": {
+	              "schema": {
+	                "type": "object",
+	                "required": ["name", "email"],
+	                "properties": {"name": {"type": "string"}, "email": {"type": "string"}}
+	              }
+	            }
+	          }
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "delete": {
+	        "operationId": "deleteUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"204": {"description": "Deleted"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when required field added")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeRequiredFieldAdded {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected REQUIRED_FIELD_ADDED change")
+	}
+}
+
+func TestCompareSchemas_TypeChanged(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema changes "limit" parameter type from integer to string
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [
+	          {"name": "limit", "in": "query", "required": false, "schema": {"type": "string"}}
+	        ],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "delete": {
+	        "operationId": "deleteUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"204": {"description": "Deleted"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when type changed")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeTypeChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected TYPE_CHANGED change")
+	}
+}
+
+func TestCompareSchemas_CompatibleTypeChange(t *testing.T) {
+	// integer → number is a compatible widening
+	oldSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "parameters": [{"name": "val", "in": "query", "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      }
+	    }
+	  }
+	}`
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "2.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "parameters": [{"name": "val", "in": "query", "schema": {"type": "number"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      }
+	    }
+	  }
+	}`
+	oldDoc := mustParseSchema(t, oldSchema)
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if !compatible {
+		t.Errorf("expected compatible for integer→number, got %d changes", len(changes))
+		for _, c := range changes {
+			t.Logf("  %s: %s", c.Type, c.Description)
+		}
+	}
+}
+
+func TestCompareSchemas_EnumValueRemoved(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema removes "50" from limit enum
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [
+	          {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "enum": [10, 20]}}
+	        ],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "delete": {
+	        "operationId": "deleteUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"204": {"description": "Deleted"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when enum value removed")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeEnumValueRemoved {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected ENUM_VALUE_REMOVED change")
+	}
+}
+
+func TestCompareSchemas_ResponseRemoved(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema removes 200 response from GET /users/{id}
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [{"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "enum": [10, 20, 50]}}],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {
+	          "404": {"description": "Not Found"}
+	        }
+	      },
+	      "delete": {
+	        "operationId": "deleteUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"204": {"description": "Deleted"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible when response removed")
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Type == BreakingChangeResponseSchemaChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected RESPONSE_SCHEMA_CHANGED change")
+	}
+}
+
+func TestCompareSchemas_NilPaths(t *testing.T) {
+	e := NewCompatibilityEngine()
+
+	// Both nil paths
+	oldDoc := &openapi3.T{}
+	newDoc := &openapi3.T{}
+
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+	if !compatible {
+		t.Errorf("expected compatible with nil paths, got %d changes", len(changes))
+	}
+}
+
+func TestCompareSchemas_OldNilNewHasPaths(t *testing.T) {
+	e := NewCompatibilityEngine()
+
+	oldDoc := &openapi3.T{}
+	newDoc := mustParseSchema(t, compatBaseSchema)
+
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+	// Adding endpoints is not a breaking change
+	if !compatible {
+		t.Errorf("expected compatible when adding endpoints, got %d changes", len(changes))
+	}
+}
+
+func TestCompareSchemas_MultipleBreakingChanges(t *testing.T) {
+	oldDoc := mustParseSchema(t, compatBaseSchema)
+
+	// New schema: remove DELETE, add required param, change type — multiple breaks
+	newSchema := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test API", "version": "2.0.0"},
+	  "paths": {
+	    "/users": {
+	      "get": {
+	        "operationId": "listUsers",
+	        "parameters": [
+	          {"name": "limit", "in": "query", "required": false, "schema": {"type": "string"}},
+	          {"name": "sort", "in": "query", "required": true, "schema": {"type": "string"}}
+	        ],
+	        "responses": {"200": {"description": "OK"}}
+	      },
+	      "post": {
+	        "operationId": "createUser",
+	        "requestBody": {
+	          "required": true,
+	          "content": {"application/json": {"schema": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}}}
+	        },
+	        "responses": {"201": {"description": "Created"}}
+	      }
+	    },
+	    "/users/{id}": {
+	      "get": {
+	        "operationId": "getUser",
+	        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}],
+	        "responses": {"200": {"description": "OK"}}
+	      }
+	    }
+	  }
+	}`
+	newDoc := mustParseSchema(t, newSchema)
+
+	e := NewCompatibilityEngine()
+	changes, compatible := e.CompareSchemas(oldDoc, newDoc)
+
+	if compatible {
+		t.Fatal("expected incompatible with multiple breaking changes")
+	}
+
+	if len(changes) < 2 {
+		t.Errorf("expected multiple breaking changes, got %d", len(changes))
+	}
+}
+
+func TestIsCompatibleTypeChange(t *testing.T) {
+	tests := []struct {
+		oldType    string
+		newType    string
+		compatible bool
+	}{
+		{"integer", "number", true},
+		{"integer", "string", false},
+		{"int32", "int64", true},
+		{"int32", "integer", true},
+		{"int32", "number", true},
+		{"int64", "number", true},
+		{"float", "double", true},
+		{"float", "number", true},
+		{"string", "integer", false},
+		{"string", "string", false}, // same type, not in map
+		{"boolean", "string", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.oldType+"_to_"+tt.newType, func(t *testing.T) {
+			result := isCompatibleTypeChange(tt.oldType, tt.newType)
+			if result != tt.compatible {
+				t.Errorf("isCompatibleTypeChange(%q, %q) = %v, want %v", tt.oldType, tt.newType, result, tt.compatible)
+			}
+		})
+	}
+}

--- a/pkg/cvt/generator_test.go
+++ b/pkg/cvt/generator_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 const testSchemaWithExamples = `{
@@ -722,6 +724,649 @@ func TestGenerateValue_TypelessSchemaWithProperties(t *testing.T) {
 	}
 	if body["name"] == nil {
 		t.Error("expected 'name' field in generated object")
+	}
+}
+
+func TestGenerateNumber_Default(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"number"}
+	result := v.generateNumber(schema)
+	if result != 123.45 {
+		t.Errorf("expected 123.45, got %v", result)
+	}
+}
+
+func TestGenerateNumber_WithEnum(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"number"}
+	schema.Enum = []interface{}{42.5}
+	result := v.generateNumber(schema)
+	if result != 42.5 {
+		t.Errorf("expected 42.5, got %v", result)
+	}
+}
+
+func TestGenerateNumber_WithMin(t *testing.T) {
+	v := NewValidator()
+	min := 10.0
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"number"}
+	schema.Min = &min
+	result := v.generateNumber(schema)
+	if result != 10.0 {
+		t.Errorf("expected 10.0, got %v", result)
+	}
+}
+
+func TestGenerateBoolean_Default(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"boolean"}
+	// Just verify it returns a boolean (random)
+	result := v.generateBoolean(schema)
+	_ = result // bool is always valid
+}
+
+func TestGenerateBoolean_WithEnum(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"boolean"}
+	schema.Enum = []interface{}{true}
+	result := v.generateBoolean(schema)
+	if !result {
+		t.Error("expected true from enum")
+	}
+}
+
+func TestGenerateAllOf(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "allOf": [
+	                    {"type": "object", "properties": {"id": {"type": "integer"}}},
+	                    {"type": "object", "properties": {"name": {"type": "string"}}}
+	                  ]
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("allof-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("allof-test", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	body, ok := resp.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected object, got %T", resp.Body)
+	}
+	if body["id"] == nil {
+		t.Error("expected 'id' from first allOf schema")
+	}
+	if body["name"] == nil {
+		t.Error("expected 'name' from second allOf schema")
+	}
+}
+
+func TestGetResponseForStatus_Exact(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchemaWithExamples))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("test")
+	operation, err := v.findOperation(doc, "POST", "/users")
+	if err != nil {
+		t.Fatalf("findOperation failed: %v", err)
+	}
+
+	resp, err := v.getResponseForStatus(operation, 201)
+	if err != nil {
+		t.Fatalf("getResponseForStatus failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response for status 201")
+	}
+}
+
+func TestGetResponseForStatus_Default(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "default": {
+	            "description": "Default response",
+	            "content": {"application/json": {"schema": {"type": "object"}}}
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("default-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("default-test")
+	operation, err := v.findOperation(doc, "GET", "/test")
+	if err != nil {
+		t.Fatalf("findOperation failed: %v", err)
+	}
+
+	resp, err := v.getResponseForStatus(operation, 200)
+	if err != nil {
+		t.Fatalf("getResponseForStatus with default should not fail: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected default response")
+	}
+}
+
+func TestGetResponseForStatus_Wildcard(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "2XX": {
+	            "description": "Success",
+	            "content": {"application/json": {"schema": {"type": "object"}}}
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("wildcard-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("wildcard-test")
+	operation, err := v.findOperation(doc, "GET", "/test")
+	if err != nil {
+		t.Fatalf("findOperation failed: %v", err)
+	}
+
+	resp, err := v.getResponseForStatus(operation, 200)
+	if err != nil {
+		t.Fatalf("getResponseForStatus with wildcard should not fail: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected wildcard response")
+	}
+}
+
+func TestGetResponseForStatus_NotFound(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchemaWithExamples))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("test")
+	operation, err := v.findOperation(doc, "GET", "/users/{id}")
+	if err != nil {
+		t.Fatalf("findOperation failed: %v", err)
+	}
+
+	// Status 500 doesn't exist and no default
+	_, err = v.getResponseForStatus(operation, 500)
+	if err == nil {
+		t.Error("expected error for non-existent status")
+	}
+}
+
+func TestGetResponseForStatus_NilResponses(t *testing.T) {
+	v := NewValidator()
+	operation := &openapi3.Operation{}
+	_, err := v.getResponseForStatus(operation, 200)
+	if err == nil {
+		t.Error("expected error for nil responses")
+	}
+}
+
+func TestSelectSuccessStatus_Preferred(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchemaWithExamples))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("test")
+
+	// GET /users has 200 → should select 200
+	getOp, _ := v.findOperation(doc, "GET", "/users")
+	status := v.selectSuccessStatus(getOp)
+	if status != 200 {
+		t.Errorf("expected 200 for GET /users, got %d", status)
+	}
+
+	// POST /users has 201 → should select 201
+	postOp, _ := v.findOperation(doc, "POST", "/users")
+	status = v.selectSuccessStatus(postOp)
+	if status != 201 {
+		t.Errorf("expected 201 for POST /users, got %d", status)
+	}
+}
+
+func TestSelectSuccessStatus_NilResponses(t *testing.T) {
+	v := NewValidator()
+	operation := &openapi3.Operation{}
+	status := v.selectSuccessStatus(operation)
+	if status != 200 {
+		t.Errorf("expected 200 for nil responses, got %d", status)
+	}
+}
+
+func TestSelectSuccessStatus_NonPreferred2XX(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "203": {"description": "Non-Authoritative Info"}
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("non-preferred", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("non-preferred")
+	op, _ := v.findOperation(doc, "GET", "/test")
+	status := v.selectSuccessStatus(op)
+	if status != 203 {
+		t.Errorf("expected 203 for non-preferred 2XX, got %d", status)
+	}
+}
+
+func TestSelectSuccessStatus_OnlyNon2XX(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "301": {"description": "Moved"},
+	          "default": {"description": "Default"}
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("non-2xx", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	doc, _ := v.GetSchema("non-2xx")
+	op, _ := v.findOperation(doc, "GET", "/test")
+	status := v.selectSuccessStatus(op)
+	// Should fall back to first available non-default code
+	if status != 301 {
+		t.Errorf("expected 301 as fallback, got %d", status)
+	}
+}
+
+func TestGenerateFixture_WithPathParams(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchemaWithExamples))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	fixture, err := v.GenerateFixture("test", "GET", "/users/{id}", opts)
+	if err != nil {
+		t.Fatalf("GenerateFixture failed: %v", err)
+	}
+
+	// Path should have {id} resolved
+	if strings.Contains(fixture.Request.Path, "{id}") {
+		t.Errorf("expected path param to be resolved, got %s", fixture.Request.Path)
+	}
+}
+
+func TestGenerateFixture_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	opts := DefaultGenerateOptions()
+	_, err := v.GenerateFixture("nonexistent", "GET", "/test", opts)
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}
+
+func TestGenerateValue_OneOf(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "oneOf": [
+	                    {"type": "string"},
+	                    {"type": "integer"}
+	                  ]
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("oneof-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("oneof-test", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	// Should pick first oneOf (string)
+	if _, ok := resp.Body.(string); !ok {
+		t.Errorf("expected string from oneOf[0], got %T", resp.Body)
+	}
+}
+
+func TestGenerateValue_AnyOf(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "anyOf": [
+	                    {"type": "integer"},
+	                    {"type": "string"}
+	                  ]
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("anyof-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("anyof-test", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	// Should pick first anyOf (integer)
+	if resp.Body == nil {
+		t.Fatal("expected non-nil body from anyOf")
+	}
+}
+
+func TestGenerateValue_DepthLimit(t *testing.T) {
+	v := NewValidator()
+	doc := &openapi3.T{}
+	schemaRef := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{},
+	}
+	schemaRef.Value.Type = &openapi3.Types{"object"}
+	schemaRef.Value.Properties = openapi3.Schemas{
+		"self": schemaRef, // self-referencing
+	}
+
+	result := v.generateValue(doc, schemaRef, false, 11)
+	if result != nil {
+		t.Errorf("expected nil at depth > 10, got %v", result)
+	}
+}
+
+func TestGenerateValue_NilSchemaRef(t *testing.T) {
+	v := NewValidator()
+	doc := &openapi3.T{}
+	result := v.generateValue(doc, nil, false, 0)
+	if result != nil {
+		t.Errorf("expected nil for nil schemaRef, got %v", result)
+	}
+}
+
+func TestGenerateString_MoreFormats(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		format   string
+		expected string
+	}{
+		{"hostname", "example.com"},
+		{"ipv6", "::1"},
+		{"byte", "c3RyaW5n"},
+		{"binary", "binary-data"},
+		{"password", "********"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			schema := &openapi3.Schema{Format: tt.format}
+			schema.Type = &openapi3.Types{"string"}
+			result := v.generateString(schema)
+			if result != tt.expected {
+				t.Errorf("generateString(%q) = %q, want %q", tt.format, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateString_Pattern(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{Pattern: `^\d{3}-\d{4}$`}
+	schema.Type = &openapi3.Types{"string"}
+	result := v.generateString(schema)
+	if result != "pattern-value" {
+		t.Errorf("expected 'pattern-value', got %q", result)
+	}
+}
+
+func TestGenerateInteger_WithEnum(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"integer"}
+	schema.Enum = []interface{}{float64(42)}
+	result := v.generateInteger(schema)
+	if result != 42 {
+		t.Errorf("expected 42, got %d", result)
+	}
+}
+
+func TestGenerateInteger_Int64Format(t *testing.T) {
+	v := NewValidator()
+	schema := &openapi3.Schema{Format: "int64"}
+	schema.Type = &openapi3.Types{"integer"}
+	result := v.generateInteger(schema)
+	if result != 1234567890 {
+		t.Errorf("expected 1234567890, got %d", result)
+	}
+}
+
+func TestGenerateInteger_WithMin(t *testing.T) {
+	v := NewValidator()
+	min := 5.0
+	schema := &openapi3.Schema{}
+	schema.Type = &openapi3.Types{"integer"}
+	schema.Min = &min
+	result := v.generateInteger(schema)
+	if result != 5 {
+		t.Errorf("expected 5, got %d", result)
+	}
+}
+
+func TestGenerateArray_MinItems(t *testing.T) {
+	schemaJSON := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "paths": {
+	    "/test": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {
+	                  "type": "array",
+	                  "minItems": 3,
+	                  "items": {"type": "string"}
+	                }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("minitems-test", []byte(schemaJSON))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.UseExamples = false
+	resp, err := v.GenerateResponse("minitems-test", "GET", "/test", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+
+	arr, ok := resp.Body.([]interface{})
+	if !ok {
+		t.Fatalf("expected array, got %T", resp.Body)
+	}
+	if len(arr) < 3 {
+		t.Errorf("expected at least 3 items (minItems), got %d", len(arr))
+	}
+}
+
+func TestGenerateRequestBody_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	opts := DefaultGenerateOptions()
+	_, err := v.GenerateRequestBody("nonexistent", "POST", "/test", opts)
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}
+
+func TestGenerateFixtureJSON_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	opts := DefaultGenerateOptions()
+	_, err := v.GenerateFixtureJSON("nonexistent", "POST", "/test", opts)
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}
+
+func TestListEndpoints_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	_, err := v.ListEndpoints("nonexistent")
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}
+
+func TestGetResponseExample_SchemaNotFound(t *testing.T) {
+	v := NewValidator()
+	_, err := v.GetResponseExample("nonexistent", "GET", "/test", 200)
+	if err == nil {
+		t.Error("expected error for non-existent schema")
+	}
+}
+
+func TestGenerateResponse_NoContent(t *testing.T) {
+	// 404 response without content — should generate response with no body
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchemaWithExamples))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	opts := DefaultGenerateOptions()
+	opts.StatusCode = 404
+	resp, err := v.GenerateResponse("test", "GET", "/users/{id}", opts)
+	if err != nil {
+		t.Fatalf("GenerateResponse failed: %v", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 

--- a/pkg/cvt/validator_test.go
+++ b/pkg/cvt/validator_test.go
@@ -1,6 +1,10 @@
 package cvt
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -322,5 +326,311 @@ func TestValidateRequest_SchemaNotFound(t *testing.T) {
 	_, err := v.ValidateRequest("nonexistent", "GET", "/test", nil, "")
 	if err == nil {
 		t.Error("expected error for non-existent schema")
+	}
+}
+
+// sharedSchemaPath returns the path to a shared test schema file.
+func sharedSchemaPath(t *testing.T, filename string) string {
+	t.Helper()
+	// From pkg/cvt/ go up two levels to repo root, then into sdks/shared/
+	path := filepath.Join("..", "..", "sdks", "shared", filename)
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("shared schema %s not found: %v", filename, err)
+	}
+	return path
+}
+
+func TestRegisterSchemaFromFile_OpenAPIv3(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchemaFromFile("test-v3", sharedSchemaPath(t, "openapi.json"))
+	if err != nil {
+		t.Fatalf("RegisterSchemaFromFile failed for v3: %v", err)
+	}
+
+	schemas := v.ListSchemas()
+	if len(schemas) != 1 || schemas[0] != "test-v3" {
+		t.Errorf("expected [test-v3], got %v", schemas)
+	}
+}
+
+func TestRegisterSchemaFromFile_Swagger(t *testing.T) {
+	// RegisterSchemaFromFile's loadSwaggerFile fallback doesn't do v2→v3 conversion,
+	// so swagger files fail validation. This test verifies the fallback path is exercised
+	// (loadSwaggerFile is called) even though it ultimately fails.
+	v := NewValidator()
+	err := v.RegisterSchemaFromFile("test-swagger", sharedSchemaPath(t, "swagger.json"))
+	// The swagger file loads but fails v3 validation — this exercises both the
+	// primary load path and the loadSwaggerFile fallback.
+	if err == nil {
+		// If it succeeds in future (e.g., kin-openapi adds auto-conversion), that's fine
+		_, ok := v.GetSchema("test-swagger")
+		if !ok {
+			t.Error("expected swagger schema to be registered")
+		}
+	}
+}
+
+func TestRegisterSchemaFromFile_NotFound(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchemaFromFile("missing", "/nonexistent/path/schema.json")
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}
+
+func TestRegisterSchemaFromURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testSchema))
+	}))
+	defer ts.Close()
+
+	v := NewValidator()
+	err := v.RegisterSchemaFromURL("url-test", ts.URL)
+	if err != nil {
+		t.Fatalf("RegisterSchemaFromURL failed: %v", err)
+	}
+
+	_, ok := v.GetSchema("url-test")
+	if !ok {
+		t.Error("expected schema to be registered from URL")
+	}
+}
+
+func TestRegisterSchemaFromURL_BadStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	v := NewValidator()
+	err := v.RegisterSchemaFromURL("bad-status", ts.URL)
+	if err == nil {
+		t.Error("expected error for 500 status")
+	}
+}
+
+func TestRegisterSchemaFromURL_InvalidContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not valid json"))
+	}))
+	defer ts.Close()
+
+	v := NewValidator()
+	err := v.RegisterSchemaFromURL("invalid", ts.URL)
+	if err == nil {
+		t.Error("expected error for invalid schema content")
+	}
+}
+
+func TestRegisterSchemaFromPath_File(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchemaFromPath("path-file", sharedSchemaPath(t, "openapi.json"))
+	if err != nil {
+		t.Fatalf("RegisterSchemaFromPath (file) failed: %v", err)
+	}
+
+	_, ok := v.GetSchema("path-file")
+	if !ok {
+		t.Error("expected schema registered via file path")
+	}
+}
+
+func TestRegisterSchemaFromPath_URL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testSchema))
+	}))
+	defer ts.Close()
+
+	v := NewValidator()
+	err := v.RegisterSchemaFromPath("path-url", ts.URL)
+	if err != nil {
+		t.Fatalf("RegisterSchemaFromPath (URL) failed: %v", err)
+	}
+
+	_, ok := v.GetSchema("path-url")
+	if !ok {
+		t.Error("expected schema registered via URL path")
+	}
+}
+
+func TestValidateWithSchema(t *testing.T) {
+	v := NewValidator()
+	interaction := &Interaction{
+		Method:       "GET",
+		Path:         "/pets",
+		StatusCode:   200,
+		ResponseBody: `[{"id": 1, "name": "Fluffy"}]`,
+		ResponseHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result, err := v.ValidateWithSchema([]byte(testSchema), interaction)
+	if err != nil {
+		t.Fatalf("ValidateWithSchema failed: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateWithSchema_InvalidSchema(t *testing.T) {
+	v := NewValidator()
+	interaction := &Interaction{
+		Method:     "GET",
+		Path:       "/test",
+		StatusCode: 200,
+	}
+
+	_, err := v.ValidateWithSchema([]byte("not json"), interaction)
+	if err == nil {
+		t.Error("expected error for invalid schema")
+	}
+}
+
+func TestParseSchema_Swagger2(t *testing.T) {
+	swagger2 := `{
+		"swagger": "2.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"host": "localhost",
+		"basePath": "/api",
+		"paths": {
+			"/pets": {
+				"get": {
+					"produces": ["application/json"],
+					"responses": {
+						"200": {
+							"description": "OK",
+							"schema": {"type": "array", "items": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	v := NewValidator()
+	doc, err := v.parseSchema([]byte(swagger2))
+	if err != nil {
+		t.Fatalf("parseSchema failed for swagger 2.0: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil doc")
+	}
+}
+
+func TestParseSchema_UnsupportedFormat(t *testing.T) {
+	v := NewValidator()
+	_, err := v.parseSchema([]byte(`{"version": "1.0"}`))
+	if err == nil {
+		t.Error("expected error for unsupported format")
+	}
+}
+
+func TestValidate_WithBasePath(t *testing.T) {
+	// Schema with server basePath
+	schemaWithBasePath := `{
+	  "openapi": "3.0.0",
+	  "info": {"title": "Test", "version": "1.0.0"},
+	  "servers": [{"url": "http://api.example.com/v1"}],
+	  "paths": {
+	    "/pets": {
+	      "get": {
+	        "responses": {
+	          "200": {
+	            "description": "OK",
+	            "content": {
+	              "application/json": {
+	                "schema": {"type": "array", "items": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	v := NewValidator()
+	err := v.RegisterSchema("basepath", []byte(schemaWithBasePath))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	// Request with basePath prefix should be stripped
+	interaction := &Interaction{
+		Method:       "GET",
+		Path:         "/v1/pets",
+		StatusCode:   200,
+		ResponseBody: `[{"id": 1}]`,
+		ResponseHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result, err := v.Validate("basepath", interaction)
+	if err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid with basePath stripping, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidate_WithHeaders(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	interaction := &Interaction{
+		Method:       "GET",
+		Path:         "/pets",
+		Headers:      map[string]string{"Accept": "application/json"},
+		StatusCode:   200,
+		ResponseBody: `[{"id": 1, "name": "Fluffy"}]`,
+		ResponseHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result, err := v.Validate("test", interaction)
+	if err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid with headers, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidate_InvalidRequestBody(t *testing.T) {
+	v := NewValidator()
+	err := v.RegisterSchema("test", []byte(testSchema))
+	if err != nil {
+		t.Fatalf("RegisterSchema failed: %v", err)
+	}
+
+	// POST with missing required field in request
+	interaction := &Interaction{
+		Method:       "POST",
+		Path:         "/pets",
+		Headers:      map[string]string{"Content-Type": "application/json"},
+		Body:         `{"tag": "cat"}`, // missing required "name"
+		StatusCode:   201,
+		ResponseBody: `{"id": 1, "name": "Fluffy"}`,
+		ResponseHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result, err := v.Validate("test", interaction)
+	if err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected invalid for missing required request field")
 	}
 }

--- a/tools/run-all-tests.sh
+++ b/tools/run-all-tests.sh
@@ -71,13 +71,13 @@ else
   echo ">>> Starting CVT server directly (no Docker)..."
   # Build and start server in background on port 9550 to match Docker config
   echo ">>> Building server..."
-  (cd server && go build -o /tmp/cvt-server-test .) || {
+  go build -o /tmp/cvt-server-test ./cmd/cvt || {
     echo "❌ Failed to build server"
     exit 1
   }
 
   # Start server in background
-  CVT_PORT=9550 /tmp/cvt-server-test &
+  CVT_PORT=9550 /tmp/cvt-server-test serve &
   SERVER_PID=$!
 
   # Wait for server to be ready


### PR DESCRIPTION
## Summary

Raises `pkg/cvt/` test coverage from 39.3% to 87.8%, exceeding the 80% project threshold. Adds 55 new tests across three files: `compatibility_test.go` (new, 13 tests for all breaking change detection), `validator_test.go` (14 tests for file/URL/path registration, ValidateWithSchema, parseSchema, basePath handling), and `generator_test.go` (28 tests for generateNumber/Boolean/AllOf, getResponseForStatus, selectSuccessStatus, oneOf/anyOf, depth limits).

Also adds a `make test-cover` target that runs all non-postgres packages and gates on 80% coverage, and fixes a pre-existing `make test` failure where the test script tried to build `./server` instead of `./cmd/cvt`.

## Test plan
- [x] `make test` — all server + SDK tests pass
- [x] `make ci` — lint, format, and checks pass
- [x] `make test-cover` — 86.1% total coverage (excl. postgres), pkg/cvt at 87.8%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for OpenAPI schema compatibility validation and code generation.
  * Extended validator test coverage with additional scenarios and edge cases.

* **Chores**
  * Added automated coverage verification with an 80% threshold to ensure code quality.
  * Updated test infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->