### PR TITLE
chore(docs-site): upgrade Docusaurus 3.9.2 → 3.10.0

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "cvt-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.2",
-        "@docusaurus/theme-mermaid": "^3.9.2",
+        "@docusaurus/core": "^3.10.0",
+        "@docusaurus/preset-classic": "^3.10.0",
+        "@docusaurus/theme-mermaid": "^3.10.0",
         "@easyops-cn/docusaurus-search-local": "^0.52.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
@@ -19,9 +19,9 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.9.2",
-        "@docusaurus/tsconfig": "^3.9.2",
-        "@docusaurus/types": "^3.9.2",
+        "@docusaurus/module-type-aliases": "^3.10.0",
+        "@docusaurus/tsconfig": "^3.10.0",
+        "@docusaurus/types": "^3.10.0",
         "typescript": "~5.6.0"
       },
       "engines": {
@@ -29,46 +29,46 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.0.tgz",
-      "integrity": "sha512-alHFZ68/i9qLC/muEB07VQ9r7cB8AvCcGX6dVQi2PNHhc/ZQRmmFAv8KK1ay4UiseGSFr7f0nXBKsZ/jRg7e4g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
+      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+        "@algolia/autocomplete-shared": "1.19.8"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-shared": "1.19.8"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -76,99 +76,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.0.tgz",
-      "integrity": "sha512-mfgUdLQNxOAvCZUGzPQxjahEWEPuQkKlV0ZtGmePOa9ZxIQZlk31vRBNbM6ScU8jTH41SCYE77G/lCifDr1SVw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
+      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.0.tgz",
-      "integrity": "sha512-5mjokeKYyPaP3Q8IYJEnutI+O4dW/Ixxx5IgsSxT04pCfGqPXxTOH311hTQxyNpcGGEOGrMv8n8Z+UMTPamioQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
+      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.0.tgz",
-      "integrity": "sha512-emtOvR6dl3rX3sBJXXbofMNHU1qMQqQSWu319RMrNL5BWoBqyiq7y0Zn6cjJm7aGHV/Qbf+KCCYeWNKEMPI3BQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
+      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.0.tgz",
-      "integrity": "sha512-IerGH2/hcj/6bwkpQg/HHRqmlGN1XwygQWythAk0gZFBrghs9danJaYuSS3ShzLSVoIVth4jY5GDPX9Lbw5cgg==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
+      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.0.tgz",
-      "integrity": "sha512-3idPJeXn5L0MmgP9jk9JJqblrQ/SguN93dNK9z9gfgyupBhHnJMOEjrRYcVgTIfvG13Y04wO+Q0FxE2Ut8PVbA==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
+      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.0.tgz",
-      "integrity": "sha512-q7qRoWrQK1a8m5EFQEmPlo7+pg9mVQ8X5jsChtChERre0uS2pdYEDixBBl0ydBSGkdGbLUDufcACIhH/077E4g==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
+      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.0.tgz",
-      "integrity": "sha512-Jc360x4yqb3eEg4OY4KEIdGePBxZogivKI+OGIU8aLXgAYPTECvzeOBc90312yHA1hr3AeRlAFl0rIc8lQaIrQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
+      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -181,81 +181,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.0.tgz",
-      "integrity": "sha512-OS3/Viao+NPpyBbEY3tf6hLewppG+UclD+9i0ju56mq2DrdMJFCkEky6Sk9S5VPcbLzxzg3BqBX6u9Q35w19aQ==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
+      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.0.tgz",
-      "integrity": "sha512-/znwgSiGufpbJVIoDmeQaHtTq+OMdDawFRbMSJVv+12n79hW+qdQXS8/Uu3BD3yn0BzgVFJEvrsHrCsInZKdhw==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
+      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.0.tgz",
-      "integrity": "sha512-dHjUfu4jfjdQiKDpCpAnM7LP5yfG0oNShtfpF5rMCel6/4HIoqJ4DC4h5GKDzgrvJYtgAhblo0AYBmOM00T+lQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
+      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.0.tgz",
-      "integrity": "sha512-bffIbUljAWnh/Ctu5uScORajuUavqmZ0ACYd1fQQeSSYA9NNN83ynO26pSc2dZRXpSK0fkc1//qSSFXMKGu+aw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
+      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.0.tgz",
-      "integrity": "sha512-y0EwNvPGvkM+yTAqqO6Gpt9wVGm3CLDtpLvNEiB3VGvN3WzfkjZGtLUsG/ru2kVJIIU7QcV0puuYgEpBeFxcJg==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
+      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.0.tgz",
-      "integrity": "sha512-xpwefe4fCOWnZgXCbkGpqQY6jgBSCf2hmgnySbyzZIccrv3SoashHKGPE4x6vVG+gdHrGciMTAcDo9HOZwH22Q==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
+      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -1930,18 +1930,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -3368,9 +3356,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-enu1vGI9GVV5btprUyTTRgWlxfhdlrHB06cX8NDXvMuUT8fzyhJbDO0FjeLgChnAB2lr1lNeOc38Q7OXOi2qcA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.2.tgz",
+      "integrity": "sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3390,20 +3378,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.1.tgz",
-      "integrity": "sha512-rA+ql4MLDgUpPs3YlVuqJt8GtujXzOFdYSV/OzCO4NxXKwLgASR+/nX7qFmnJCy3g0MVthEZS2IeZzJjYzWuGg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
+      "integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.1.tgz",
-      "integrity": "sha512-9wP7fOLhF4c1IOnH6Zh0nD68Q6uY3R44X5+PRU9f9hYkDiFtUkM2z0qUby8fzHHzK3f7jEH3PiNKgJs3DCwVlg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.2.tgz",
+      "integrity": "sha512-/BbtGFtqVOGwZx0dw/UfhN/0/DmMQYnulY4iv0tPRhC2JCXv0ka/+izwt3Jzo1ZxXS/2eMvv9zHsBJOK1I9f/w==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.1",
-        "@docsearch/css": "4.6.1"
+        "@docsearch/core": "4.6.2",
+        "@docsearch/css": "4.6.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3426,10 +3414,42 @@
         }
       }
     },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+        "@algolia/autocomplete-shared": "1.19.2"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.2"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
     "node_modules/@docusaurus/babel": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
-      "integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.0.tgz",
+      "integrity": "sha512-mqCJhCZNZUDg0zgDEaPTM4DnRsisa24HdqTy/qn/MQlbwhTb4WVaZg6ZyX6yIVKqTz8fS1hBMgM+98z+BeJJDg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3440,10 +3460,9 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
-        "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3453,17 +3472,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
-      "integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.0.tgz",
+      "integrity": "sha512-iONUGZGgp+lAkw/cJZH6irONcF4p8+278IsdRlq8lYhxGjkoNUs0w7F4gVXBYSNChq5KG5/JleTSsdJySShxow==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.9.2",
-        "@docusaurus/cssnano-preset": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/babel": "3.10.0",
+        "@docusaurus/cssnano-preset": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3496,18 +3515,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
-      "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.0.tgz",
+      "integrity": "sha512-mgLdQsO8xppnQZc3LPi+Mf+PkPeyxJeIx11AXAq/14fsaMefInQiMEZUUmrc7J+956G/f7MwE7tn8KZgi3iRcA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.9.2",
-        "@docusaurus/bundler": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/babel": "3.10.0",
+        "@docusaurus/bundler": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3519,7 +3538,7 @@
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
-        "execa": "5.1.1",
+        "execa": "^5.1.1",
         "fs-extra": "^11.1.1",
         "html-tags": "^3.3.1",
         "html-webpack-plugin": "^5.6.0",
@@ -3530,12 +3549,12 @@
         "prompts": "^2.4.2",
         "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.3",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.3.4",
         "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
+        "serve-handler": "^6.1.7",
         "tinypool": "^1.0.2",
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
@@ -3551,15 +3570,21 @@
         "node": ">=20.0"
       },
       "peerDependencies": {
+        "@docusaurus/faster": "*",
         "@mdx-js/react": "^3.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/faster": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
-      "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.0.tgz",
+      "integrity": "sha512-qzSshTO1DB3TYW+dPUal5KHM7XPc5YQfzF3Kdb2NDACJUyGbNcFtw3tGkCJlYwhNCRKbZcmwraKUS1i5dcHdGg==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3572,9 +3597,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-      "integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.0.tgz",
+      "integrity": "sha512-9jrZzFuBH1LDRlZ7cznAhCLmAZ3HSDqgwdrSSZdGHq9SPUOQgXXu8mnxe2ZRB9NS1PCpMTIOVUqDtZPIhMafZg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3585,14 +3610,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-      "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.0.tgz",
+      "integrity": "sha512-mQQV97080AH4PYNs087l202NMDqRopZA4mg5W76ZZyTFrmWhJ3mHg+8A+drJVENxw5/Q+wHMHLgsx+9z1nEs0A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3624,12 +3649,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
+      "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.2",
+        "@docusaurus/types": "3.10.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3643,20 +3668,21 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
-      "integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.0.tgz",
+      "integrity": "sha512-RuTz68DhB7CL96QO5UsFbciD7GPYq6QV+YMfF9V0+N4ZgLhJIBgpVAr8GobrKF6NRe5cyWWETU5z5T834piG9g==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "cheerio": "1.0.0-rc.12",
+        "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3677,20 +3703,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-      "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.0.tgz",
+      "integrity": "sha512-9BjHhf15ct8Z7TThTC0xRndKDVvMKmVsAGAN7W9FpNRzfMdScOGcXtLmcCWtJGvAezjOJIm6CxOYCy3Io5+RnQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3710,16 +3736,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
-      "integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.0.tgz",
+      "integrity": "sha512-5amX8kEJI+nIGtuLVjYk59Y5utEJ3CHETFOPEE4cooIRLA4xM4iBsA6zFgu4ljcopeYwvBzFEWf5g2I6Yb9SkA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3733,15 +3759,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
-      "integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.0.tgz",
+      "integrity": "sha512-6q1vtt5FJcg5osgkHeM1euErECNqEZ5Z1j69yiNx2luEBIso+nxCkS9nqj8w+MK5X7rvKEToGhFfOFWncs51pQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3749,14 +3775,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
-      "integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.0.tgz",
+      "integrity": "sha512-XcljKN+G+nmmK69uQA1d9BlYU3ZftG3T3zpK8/7Hf/wrOlV7TA4Ampdrdwkg0jElKdKAoSnPhCO0/U3bQGsVQQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3770,14 +3796,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
-      "integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.0.tgz",
+      "integrity": "sha512-hTEoodatpBZnUat5nFExbuTGA1lhWGy7vZGuTew5Q3QDtGKFpSJLYmZJhdTjvCFwv1+qQ67hgAVlKdJOB8TXow==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3789,15 +3815,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
-      "integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.0.tgz",
+      "integrity": "sha512-iB/Zzjv/eelJRbdULZqzWCbgMgJ7ht4ONVjXtN3+BI/muil6S87gQ1OJyPwlXD+ELdKkitC7bWv5eJdYOZLhrQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@types/gtag.js": "^0.0.12",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
+        "@types/gtag.js": "^0.0.20",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3809,14 +3835,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
-      "integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.0.tgz",
+      "integrity": "sha512-FEjZxqKgLHa+Wez/EgKxRwvArNCWIScfyEQD95rot7jkxp6nonjI5XIbGfO/iYhM5Qinwe8aIEQHP2KZtpqVuA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3828,17 +3854,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
-      "integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.0.tgz",
+      "integrity": "sha512-DVTSLjB97hIjmayGnGcBfognCeI7ZuUKgEnU7Oz81JYqXtVg94mVTthDjq3QHTylYNeCUbkaW8VF0FDLcc8pPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3852,15 +3878,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
-      "integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.0.tgz",
+      "integrity": "sha512-lNljBESaETZqVBMPqkrGchr+UPT1eZzEPLmJhz8I76BxbjqgsUnRvrq6lQJ9sYjgmgX52KB7kkgczqd2yzoswQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3875,26 +3901,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
-      "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.0.tgz",
+      "integrity": "sha512-kw/Ye02Hc6xP1OdTswy8yxQEHg0fdPpyWAQRxr5b2x3h7LlG2Zgbb5BDFROnXDDMpUxB7YejlocJIE5HIEfpNA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/plugin-content-blog": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/plugin-content-pages": "3.9.2",
-        "@docusaurus/plugin-css-cascade-layers": "3.9.2",
-        "@docusaurus/plugin-debug": "3.9.2",
-        "@docusaurus/plugin-google-analytics": "3.9.2",
-        "@docusaurus/plugin-google-gtag": "3.9.2",
-        "@docusaurus/plugin-google-tag-manager": "3.9.2",
-        "@docusaurus/plugin-sitemap": "3.9.2",
-        "@docusaurus/plugin-svgr": "3.9.2",
-        "@docusaurus/theme-classic": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-search-algolia": "3.9.2",
-        "@docusaurus/types": "3.9.2"
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/plugin-content-blog": "3.10.0",
+        "@docusaurus/plugin-content-docs": "3.10.0",
+        "@docusaurus/plugin-content-pages": "3.10.0",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.0",
+        "@docusaurus/plugin-debug": "3.10.0",
+        "@docusaurus/plugin-google-analytics": "3.10.0",
+        "@docusaurus/plugin-google-gtag": "3.10.0",
+        "@docusaurus/plugin-google-tag-manager": "3.10.0",
+        "@docusaurus/plugin-sitemap": "3.10.0",
+        "@docusaurus/plugin-svgr": "3.10.0",
+        "@docusaurus/theme-classic": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/theme-search-algolia": "3.10.0",
+        "@docusaurus/types": "3.10.0"
       },
       "engines": {
         "node": ">=20.0"
@@ -3905,26 +3931,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
-      "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.0.tgz",
+      "integrity": "sha512-9msCAsRdN+UG+RwPwCFb0uKy4tGoPh5YfBozXeGUtIeAgsMdn6f3G/oY861luZ3t8S2ET8S9Y/1GnpJAGWytww==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/plugin-content-blog": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/plugin-content-pages": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-translations": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/plugin-content-blog": "3.10.0",
+        "@docusaurus/plugin-content-docs": "3.10.0",
+        "@docusaurus/plugin-content-pages": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/theme-translations": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
@@ -3945,15 +3972,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.0.tgz",
+      "integrity": "sha512-Dkp1YXKn16ByCJAdIjbDIOpVb4Z66MsVD694/ilX1vAAHaVEMrVsf/NPd9VgreyFx08rJ9GqV1MtzsbTcU73Kg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/mdx-loader": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3973,16 +4000,16 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.9.2.tgz",
-      "integrity": "sha512-5vhShRDq/ntLzdInsQkTdoKWSzw8d1jB17sNPYhA/KvYYFXfuVEGHLM6nrf8MFbV8TruAHDG21Fn3W4lO8GaDw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.0.tgz",
+      "integrity": "sha512-Y2xrlwhIJ80oOZIO3PXL6A7J869splfcMI87E3NKpYsy3zJxOyV+BP1QMtGi59ajKgU868HPuyyn6J+6BZGOBg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
@@ -4001,19 +4028,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
-      "integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.0.tgz",
+      "integrity": "sha512-f5FPKI08e3JRG63vR/o4qeuUVHUHzFzM0nnF+AkB67soAZgNsKJRf2qmUZvlQkGwlV+QFkKe4D0ANMh1jToU3g==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.9.0 || ^4.1.0",
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-translations": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@algolia/autocomplete-core": "^1.19.2",
+        "@docsearch/react": "^3.9.0 || ^4.3.2",
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/plugin-content-docs": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/theme-translations": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4032,9 +4060,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
-      "integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.0.tgz",
+      "integrity": "sha512-L9IbFLwTc5+XdgH45iQYufLn0SVZd6BUNelDbKIFlH+E4hhjuj/XHWAFMX/w2K59rfy8wak9McOaei7BSUfRPA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4045,16 +4073,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
-      "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.0.tgz",
+      "integrity": "sha512-TXdC3WXuPrdQAexLvjUJfnYf3YKEgEqAs5nK0Q88pRBCW7t7oN4ILvWYb3A5Z1wlSXyXGWW/mCUmLEhdWsjnDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
+      "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4088,16 +4116,16 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-      "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.0.tgz",
+      "integrity": "sha512-T3B0WTigsIthe0D4LQa2k+7bJY+c3WS+Wq2JhcznOSpn1lSN64yNtHQXboCj3QnUs1EuAZszQG1SHKu5w5ZrlA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
         "escape-string-regexp": "^4.0.0",
-        "execa": "5.1.1",
+        "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
@@ -4120,12 +4148,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-      "integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.0.tgz",
+      "integrity": "sha512-JyL7sb9QVDgYvudIS81Dv0lsWm7le0vGZSDwsztxWam1SPBqrnkvBy9UYL/amh6pbybkyYTd3CMTkO24oMlCSw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.2",
+        "@docusaurus/types": "3.10.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4133,14 +4161,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-      "integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
+      "integrity": "sha512-c+6n2+ZPOJtWWc8Bb/EYdpSDfjYEScdCu9fB/SNjOmSCf1IdVnGf2T53o0tsz0gDRtCL90tifTL0JE/oMuP1Mw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/logger": "3.10.0",
+        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/utils-common": "3.10.0",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -6103,9 +6131,9 @@
       "license": "MIT"
     },
     "node_modules/@types/gtag.js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -6705,25 +6733,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.0.tgz",
-      "integrity": "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
+      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.0",
-        "@algolia/client-abtesting": "5.50.0",
-        "@algolia/client-analytics": "5.50.0",
-        "@algolia/client-common": "5.50.0",
-        "@algolia/client-insights": "5.50.0",
-        "@algolia/client-personalization": "5.50.0",
-        "@algolia/client-query-suggestions": "5.50.0",
-        "@algolia/client-search": "5.50.0",
-        "@algolia/ingestion": "1.50.0",
-        "@algolia/monitoring": "1.50.0",
-        "@algolia/recommend": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/abtesting": "1.16.2",
+        "@algolia/client-abtesting": "5.50.2",
+        "@algolia/client-analytics": "5.50.2",
+        "@algolia/client-common": "5.50.2",
+        "@algolia/client-insights": "5.50.2",
+        "@algolia/client-personalization": "5.50.2",
+        "@algolia/client-query-suggestions": "5.50.2",
+        "@algolia/client-search": "5.50.2",
+        "@algolia/ingestion": "1.50.2",
+        "@algolia/monitoring": "1.50.2",
+        "@algolia/recommend": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -6897,9 +6925,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "funding": [
         {
           "type": "opencollective",
@@ -6916,8 +6944,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -7023,9 +7051,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7182,9 +7210,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7201,11 +7229,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7281,14 +7309,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -7371,9 +7399,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7924,6 +7952,18 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/copy-text-to-clipboard": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+      "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -8010,17 +8050,6 @@
       "dependencies": {
         "browserslist": "^4.28.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-      "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -8147,9 +8176,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
-      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
       "license": "ISC",
       "engines": {
         "node": "^14 || ^16 || >=18"
@@ -9438,9 +9467,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -14485,9 +14514,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.1.tgz",
-      "integrity": "sha512-k7G3Y5QOegl380tXmZ68foBRRjE9Ljavx835ObdvmZjQ639izvZD8CS7BkWw1qKPPzHsGL/JDhl0uyU1zc2rJw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+      "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
       "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0",
@@ -15282,9 +15311,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17094,9 +17123,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -17328,9 +17357,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -17639,11 +17668,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -15,9 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/core": "^3.10.0",
+    "@docusaurus/preset-classic": "^3.10.0",
+    "@docusaurus/theme-mermaid": "^3.10.0",
     "@easyops-cn/docusaurus-search-local": "^0.52.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
@@ -26,9 +26,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.9.2",
-    "@docusaurus/tsconfig": "^3.9.2",
-    "@docusaurus/types": "^3.9.2",
+    "@docusaurus/module-type-aliases": "^3.10.0",
+    "@docusaurus/tsconfig": "^3.10.0",
+    "@docusaurus/types": "^3.10.0",
     "typescript": "~5.6.0"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary

- Bumps `@docusaurus/{core,preset-classic,theme-mermaid,module-type-aliases,tsconfig,types}` from 3.9.2 → 3.10.0 per the update notice shown by \`make docs-dev\`.
- package.json + package-lock.json only; no docs content changes.

## Test plan

- [x] \`npm run build\` in docs-site — clean build, all pages render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docusaurus framework and related development dependencies to version 3.10.0 for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->