### PR TITLE
feat(plugins): wire fetch_schema hook at schema-by-ID resolvers

### DIFF
--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -92,7 +92,7 @@ Four hook points wired via `pkg/cvt.Hooks` (server) and `pkg/cvt.Validator.SetHo
 
 | Hook | Fires in | Maps to plugin call |
 |---|---|---|
-| `fetch_schema` | Deferred to issue #83; not wired in v1 follow-ups (target site: `pkg/cvt/validator.go` before schema-by-ID resolve) | `RegistryProvider.FetchSchema` |
+| `fetch_schema` | `server/cvtservice/validator_service.go` in `getSchemaEntry` — between cache miss and storage lookup, so a bound plugin is authoritative | `RegistryProvider.FetchSchema` |
 | `register_consumer_usage` | `server/cvtservice/consumer_registry.go` at `RegisterConsumer` success | `RegistryProvider.RegisterConsumerUsage` |
 | `on_breaking_change_detected` | `server/cvtservice/validator_service.go` at success returns of `CompareSchemas` and `RegisterSchema --check-compatibility` | `EventHandler.OnBreakingChangeDetected` |
 | `on_validation_failed` | `pkg/cvt/validator.go` after `Validate` returns a non-valid result (CLI path) | `EventHandler.OnValidationFailed` |
@@ -107,7 +107,7 @@ The `RegisterSchema --check-compatibility` flag is server-side enforced as of is
 
 Each hook invokes **at most one plugin**, chosen by config key. Fanout = v1.1.
 
-**Status:** `on_validation_failed` (CLI), `on_breaking_change_detected`, and `register_consumer_usage` are wired as of issue #107. `fetch_schema` is blocked on the issue #83 rewrite.
+**Status:** All four v1 hooks are wired. `on_validation_failed` (CLI), `on_breaking_change_detected`, and `register_consumer_usage` landed with issue #107; `fetch_schema` fires from `getSchemaEntry` on cache miss before storage fallback.
 
 ## Config
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -12,7 +12,7 @@ All four v1 hook call sites are wired today:
 
 | Hook | Plugin service | Status |
 |---|---|---|
-| `on_validation_failed` | `EventHandler` | **wired** — fires from `ValidateInteraction` after a non-valid result |
+| `on_validation_failed` | `EventHandler` | **wired** — fires from `pkg/cvt.Validator.Validate` after a non-valid result (CLI/library path) |
 | `on_breaking_change_detected` | `EventHandler` | **wired** — fires from `CompareSchemas` and from `RegisterSchema` when `--check-compatibility` is set |
 | `register_consumer_usage` | `RegistryProvider` | **wired** — fires from `RegisterConsumer` on success |
 | `fetch_schema` | `RegistryProvider` | **wired** — fires on schema cache miss, before storage fallback, for every RPC that resolves a schema by ID |

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -8,19 +8,17 @@ on their own release schedules.
 
 ## Hook call-site status
 
-Three of the four v1 hook call sites are wired today:
+All four v1 hook call sites are wired today:
 
 | Hook | Plugin service | Status |
 |---|---|---|
 | `on_validation_failed` | `EventHandler` | **wired** — fires from `ValidateInteraction` after a non-valid result |
 | `on_breaking_change_detected` | `EventHandler` | **wired** — fires from `CompareSchemas` and from `RegisterSchema` when `--check-compatibility` is set |
 | `register_consumer_usage` | `RegistryProvider` | **wired** — fires from `RegisterConsumer` on success |
-| `fetch_schema` | `RegistryProvider` | SDK + config surface only; core call site deferred pending the schema-by-ID resolution path from [issue #83](https://github.com/sahina/cvt/issues/83) |
+| `fetch_schema` | `RegistryProvider` | **wired** — fires on schema cache miss, before storage fallback, for every RPC that resolves a schema by ID |
 
 Plugins can be written, installed, and configured against all four hook
 names today. The SDK, proto contracts, and config schema are frozen.
-The unwired `fetch_schema` binding is a declarative no-op until its
-call site lands.
 
 ## When to use a plugin
 
@@ -30,8 +28,9 @@ Use a plugin when you want:
   and raw URLs. If your organization hosts schemas in a registry with its
   own API (internal Central API Registry, Backstage, Apicurio), write a
   `RegistryProvider` plugin and point `fetch_schema` / `register_consumer_usage`
-  at it. `register_consumer_usage` fires on every `RegisterConsumer`
-  today; `fetch_schema` is the one hook still awaiting its call site.
+  at it. `register_consumer_usage` fires on every `RegisterConsumer`;
+  `fetch_schema` fires on every schema cache miss before storage is
+  consulted, so a bound plugin is authoritative.
 - **Event integrations.** CVT fires events on breaking-change detection
   and validation failure. Write an `EventHandler` plugin that reacts to
   those events. Both `on_validation_failed` and `on_breaking_change_detected`

--- a/docs/plugins/config.md
+++ b/docs/plugins/config.md
@@ -20,11 +20,8 @@ hooks:
   fetch_schema: registry
 ```
 
-Run CVT; the `registry` plugin forks at startup. Three of the four
-hooks fire from core today (`on_validation_failed`,
-`on_breaking_change_detected`, `register_consumer_usage`);
-`fetch_schema` is the one exception — its call site is still pending
-(see the hook status table in `README.md`).
+Run CVT; the `registry` plugin forks at startup. All four hooks fire
+from core today — see the hook status table in `README.md`.
 
 ## Full schema
 
@@ -120,7 +117,7 @@ runs for that hook).
 | `on_validation_failed` | After `ValidateInteraction` returns a non-valid result | `EventHandler` | **wired** |
 | `on_breaking_change_detected` | After `CompareSchemas`, or after `RegisterSchema` when `check_compatibility=true` and breaking changes are detected | `EventHandler` | **wired** |
 | `register_consumer_usage` | After `RegisterConsumer` succeeds | `RegistryProvider` | **wired** |
-| `fetch_schema` | Before schema-by-ID resolution | `RegistryProvider` | declarative only; call site pending [issue #83](https://github.com/sahina/cvt/issues/83) |
+| `fetch_schema` | Before schema-by-ID resolution (on cache miss, before storage) | `RegistryProvider` | **wired** |
 
 A hook referencing a plugin that isn't declared under `plugins:` is a
 load-time error.

--- a/server/cvtservice/hooks_fire.go
+++ b/server/cvtservice/hooks_fire.go
@@ -3,9 +3,11 @@ package cvtservice
 import (
 	"context"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	eventspb "github.com/sahina/cvt/pkg/cvtplugin/pb/events/v1"
 	registrypb "github.com/sahina/cvt/pkg/cvtplugin/pb/registry/v1"
 	"github.com/sahina/cvt/server/pb"
+	"go.uber.org/zap"
 )
 
 // fireOnBreakingChangeDetected dispatches the on_breaking_change_detected
@@ -64,4 +66,89 @@ func (s *ValidatorService) fireRegisterConsumerUsage(
 		Endpoints:     convertEndpointUsage(req.UsedEndpoints),
 	}
 	_, _ = h.RegisterConsumerUsage(context.Background(), pluginReq)
+}
+
+// tryFetchSchemaFromPlugin asks the fetch_schema-bound plugin for a
+// schema before falling back to storage. Unlike the other fire helpers,
+// this one runs on the critical path — it uses the caller's ctx so the
+// plugin's per-call timeout can cancel cleanly, and its return value
+// drives control flow.
+//
+// Returns:
+//   - (entry, true, nil)   plugin supplied a usable spec; caller uses it
+//   - (nil,   false, nil)  no plugin bound, plugin returned nothing, or
+//     plugin returned malformed bytes — caller falls through to storage
+//   - (nil,   false, err)  plugin returned an error under fail_closed;
+//     caller refuses the resolution (does NOT fall through, honoring
+//     the plugin's refusal as authoritative)
+//
+// Plugin-supplied specs are cached and mirrored into the fixture
+// generator but NOT written into s.store: the plugin is a fetch, not a
+// registration, and mirroring would diverge two sources of truth.
+func (s *ValidatorService) tryFetchSchemaFromPlugin(ctx context.Context, schemaID, version string) (*SchemaEntry, bool, error) {
+	h := s.hooksOrNoop()
+	resp, err := h.FetchSchema(ctx, &registrypb.FetchSchemaRequest{
+		SchemaId: schemaID,
+		Version:  version,
+	})
+	if err != nil {
+		// Surface the error so the caller's fail-closed path fires:
+		// getSchemaEntry returns (nil,false) which collapses to NOT_FOUND
+		// at the RPC boundary (same shape as a storage error during
+		// rehydration, and matches the plugin's "I refuse to answer"
+		// intent better than masking it as a success).
+		Warn("fetch_schema plugin returned error",
+			zap.String("schemaId", schemaID),
+			zap.String("version", version),
+			zap.Error(err))
+		return nil, false, err
+	}
+	if resp == nil || len(resp.Spec) == 0 {
+		return nil, false, nil
+	}
+
+	doc, parseErr := s.parseAndConvertSchema(resp.Spec)
+	if parseErr != nil {
+		Warn("Failed to parse schema from fetch_schema plugin",
+			zap.String("schemaId", schemaID),
+			zap.Error(parseErr))
+		return nil, false, nil
+	}
+
+	loader := openapi3.NewLoader()
+	if valErr := doc.Validate(loader.Context); valErr != nil {
+		Warn("fetch_schema plugin spec failed validation",
+			zap.String("schemaId", schemaID),
+			zap.Error(valErr))
+		return nil, false, nil
+	}
+
+	entry := NewSchemaEntry(schemaID, string(resp.Spec), doc, resp.ResolvedVersion, nil)
+
+	router, routerErr := s.buildRouter(doc)
+	if routerErr != nil {
+		Warn("Failed to build router for plugin-supplied schema",
+			zap.String("schemaId", schemaID),
+			zap.Error(routerErr))
+		return nil, false, nil
+	}
+	entry.Router = router
+
+	if version == "" {
+		s.cache.Set(schemaID, entry)
+	} else {
+		s.cache.SetVersion(schemaID, resp.ResolvedVersion, entry)
+	}
+
+	if genErr := s.generator.RegisterSchema(schemaID, resp.Spec); genErr != nil {
+		Warn("Failed to register plugin-supplied schema in generator",
+			zap.String("schemaId", schemaID),
+			zap.Error(genErr))
+	}
+
+	Info("Loaded schema via fetch_schema plugin",
+		zap.String("schemaId", schemaID),
+		zap.String("version", resp.ResolvedVersion))
+
+	return entry, true, nil
 }

--- a/server/cvtservice/hooks_fire.go
+++ b/server/cvtservice/hooks_fire.go
@@ -3,7 +3,6 @@ package cvtservice
 import (
 	"context"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	eventspb "github.com/sahina/cvt/pkg/cvtplugin/pb/events/v1"
 	registrypb "github.com/sahina/cvt/pkg/cvtplugin/pb/registry/v1"
 	"github.com/sahina/cvt/server/pb"
@@ -115,15 +114,21 @@ func (s *ValidatorService) tryFetchSchemaFromPlugin(ctx context.Context, schemaI
 		return nil, false, nil
 	}
 
-	loader := openapi3.NewLoader()
-	if valErr := doc.Validate(loader.Context); valErr != nil {
+	if valErr := doc.Validate(ctx); valErr != nil {
 		Warn("fetch_schema plugin spec failed validation",
 			zap.String("schemaId", schemaID),
 			zap.Error(valErr))
 		return nil, false, nil
 	}
 
-	entry := NewSchemaEntry(schemaID, string(resp.Spec), doc, resp.ResolvedVersion, nil)
+	// Fall back to the spec's own info.version when the plugin omits
+	// ResolvedVersion — prevents empty cache keys and empty metadata.
+	resolvedVersion := resp.ResolvedVersion
+	if resolvedVersion == "" && doc.Info != nil {
+		resolvedVersion = doc.Info.Version
+	}
+
+	entry := NewSchemaEntry(schemaID, string(resp.Spec), doc, resolvedVersion, nil)
 
 	router, routerErr := s.buildRouter(doc)
 	if routerErr != nil {
@@ -137,7 +142,13 @@ func (s *ValidatorService) tryFetchSchemaFromPlugin(ctx context.Context, schemaI
 	if version == "" {
 		s.cache.Set(schemaID, entry)
 	} else {
-		s.cache.SetVersion(schemaID, resp.ResolvedVersion, entry)
+		// Cache under both the requested key and the resolved key when
+		// they differ — otherwise alias lookups (e.g. "v1" resolving to
+		// "1.2.3") pay the plugin round-trip on every call.
+		s.cache.SetVersion(schemaID, version, entry)
+		if resolvedVersion != "" && resolvedVersion != version {
+			s.cache.SetVersion(schemaID, resolvedVersion, entry)
+		}
 	}
 
 	if genErr := s.generator.RegisterSchema(schemaID, resp.Spec); genErr != nil {
@@ -148,7 +159,7 @@ func (s *ValidatorService) tryFetchSchemaFromPlugin(ctx context.Context, schemaI
 
 	Info("Loaded schema via fetch_schema plugin",
 		zap.String("schemaId", schemaID),
-		zap.String("version", resp.ResolvedVersion))
+		zap.String("version", resolvedVersion))
 
 	return entry, true, nil
 }

--- a/server/cvtservice/hooks_fire_test.go
+++ b/server/cvtservice/hooks_fire_test.go
@@ -212,6 +212,49 @@ func TestTryFetchSchemaFromPlugin_VersionedLookup_UsesVersionedSlot(t *testing.T
 	assert.True(t, versionHit)
 }
 
+func TestTryFetchSchemaFromPlugin_AliasCachedUnderBothKeys(t *testing.T) {
+	// Plugin resolves alias "v1" → "1.2.3". Both keys must land in the
+	// cache so subsequent alias lookups don't pay the plugin round-trip.
+	const aliasSpec = `{"openapi":"3.0.0","info":{"title":"Alias","version":"1.2.3"},"paths":{}}`
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{
+			Spec:            []byte(aliasSpec),
+			ResolvedVersion: "1.2.3",
+		},
+	}
+	s.SetHooks(rec)
+
+	_, ok, _ := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "v1")
+	require.True(t, ok)
+
+	_, aliasHit := s.cache.GetVersion("pet-api", "v1")
+	assert.True(t, aliasHit, "alias key must cache")
+	_, canonicalHit := s.cache.GetVersion("pet-api", "1.2.3")
+	assert.True(t, canonicalHit, "resolved canonical key must also cache")
+}
+
+func TestTryFetchSchemaFromPlugin_EmptyResolvedVersion_UsesInfoVersion(t *testing.T) {
+	// Plugin returns empty ResolvedVersion — fall back to doc.Info.Version
+	// so metadata and cache keys are never blank.
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{
+			Spec: []byte(fetchSchemaTestSpec), // info.version = 1.0.0
+		},
+	}
+	s.SetHooks(rec)
+
+	entry, ok, _ := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "")
+	require.True(t, ok)
+	require.NotNil(t, entry)
+	assert.Equal(t, "1.0.0", entry.Metadata.SchemaVersion)
+}
+
 func TestTryFetchSchemaFromPlugin_MalformedSpec_FallsThrough(t *testing.T) {
 	s, err := NewValidatorService()
 	require.NoError(t, err)

--- a/server/cvtservice/hooks_fire_test.go
+++ b/server/cvtservice/hooks_fire_test.go
@@ -9,6 +9,7 @@ import (
 	eventspb "github.com/sahina/cvt/pkg/cvtplugin/pb/events/v1"
 	registrypb "github.com/sahina/cvt/pkg/cvtplugin/pb/registry/v1"
 	"github.com/sahina/cvt/server/pb"
+	"github.com/sahina/cvt/server/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,12 +22,17 @@ type recordingHooks struct {
 	registerConsumerCalls []*registrypb.RegisterConsumerUsageRequest
 	validationFailedCalls []*eventspb.ValidationFailedRequest
 	fetchSchemaCalls      []*registrypb.FetchSchemaRequest
+	fetchSchemaResp       *registrypb.FetchSchemaResponse
+	fetchSchemaErr        error
 }
 
 func (r *recordingHooks) FetchSchema(_ context.Context, req *registrypb.FetchSchemaRequest) (*registrypb.FetchSchemaResponse, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.fetchSchemaCalls = append(r.fetchSchemaCalls, req)
+	if r.fetchSchemaResp != nil || r.fetchSchemaErr != nil {
+		return r.fetchSchemaResp, r.fetchSchemaErr
+	}
 	return nil, nil
 }
 
@@ -135,4 +141,136 @@ func TestFireRegisterConsumerUsage_FieldMapping(t *testing.T) {
 	assert.Equal(t, "GET", got.Endpoints[0].Method)
 	assert.Equal(t, "/pets/{id}", got.Endpoints[0].Path)
 	assert.Equal(t, []string{"id", "name"}, got.Endpoints[0].UsedFields, "used_fields must propagate per plugin proto v1.1")
+}
+
+const fetchSchemaTestSpec = `{"openapi":"3.0.0","info":{"title":"Test","version":"1.0.0"},"paths":{}}`
+
+func TestTryFetchSchemaFromPlugin_NoopHooks_FallsThrough(t *testing.T) {
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	// No hooks set → NoopHooks.FetchSchema returns (nil, nil) → helper
+	// signals "not found, no error" so getSchemaEntry moves on to storage.
+	entry, ok, fetchErr := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "")
+	assert.Nil(t, entry)
+	assert.False(t, ok)
+	assert.NoError(t, fetchErr)
+}
+
+func TestTryFetchSchemaFromPlugin_HappyPath_CachesEntry(t *testing.T) {
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{
+			Spec:            []byte(fetchSchemaTestSpec),
+			ResolvedVersion: "1.0.0",
+		},
+	}
+	s.SetHooks(rec)
+
+	entry, ok, fetchErr := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "")
+	require.NoError(t, fetchErr)
+	require.True(t, ok)
+	require.NotNil(t, entry)
+	assert.Equal(t, "1.0.0", entry.Metadata.SchemaVersion)
+	assert.NotNil(t, entry.Router, "router must be built for plugin-supplied specs")
+
+	require.Len(t, rec.fetchSchemaCalls, 1)
+	assert.Equal(t, "pet-api", rec.fetchSchemaCalls[0].SchemaId)
+	assert.Equal(t, "", rec.fetchSchemaCalls[0].Version, "empty version propagates as 'latest'")
+
+	// Entry must land in the bare (unversioned) slot when the lookup was
+	// unversioned — mirrors the storage-readthrough rule.
+	cached, cachedOK := s.cache.Get("pet-api")
+	assert.True(t, cachedOK)
+	assert.Same(t, entry, cached)
+}
+
+func TestTryFetchSchemaFromPlugin_VersionedLookup_UsesVersionedSlot(t *testing.T) {
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{
+			Spec:            []byte(fetchSchemaTestSpec),
+			ResolvedVersion: "2.0.0",
+		},
+	}
+	s.SetHooks(rec)
+
+	_, ok, _ := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "2.0.0")
+	require.True(t, ok)
+	require.Len(t, rec.fetchSchemaCalls, 1)
+	assert.Equal(t, "2.0.0", rec.fetchSchemaCalls[0].Version)
+
+	// Versioned-only cache write: the bare key must stay empty so an old
+	// version can't masquerade as "latest".
+	_, bareHit := s.cache.Get("pet-api")
+	assert.False(t, bareHit)
+	_, versionHit := s.cache.GetVersion("pet-api", "2.0.0")
+	assert.True(t, versionHit)
+}
+
+func TestTryFetchSchemaFromPlugin_MalformedSpec_FallsThrough(t *testing.T) {
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{Spec: []byte("{not openapi")},
+	}
+	s.SetHooks(rec)
+
+	entry, ok, fetchErr := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "")
+	assert.Nil(t, entry)
+	assert.False(t, ok)
+	assert.NoError(t, fetchErr, "malformed spec logs+falls through, does not surface error")
+}
+
+func TestTryFetchSchemaFromPlugin_PluginError_Surfaces(t *testing.T) {
+	s, err := NewValidatorService()
+	require.NoError(t, err)
+	defer s.Close()
+	rec := &recordingHooks{fetchSchemaErr: assert.AnError}
+	s.SetHooks(rec)
+
+	entry, ok, fetchErr := s.tryFetchSchemaFromPlugin(context.Background(), "pet-api", "")
+	assert.Nil(t, entry)
+	assert.False(t, ok)
+	assert.ErrorIs(t, fetchErr, assert.AnError, "fail_closed plugin error must reach caller so storage is not consulted")
+}
+
+func TestGetSchemaEntry_FetchesFromPluginBeforeStorage(t *testing.T) {
+	// Prove ordering — not just that the plugin works. Populate storage
+	// with one spec, have the plugin return a *different* spec, show that
+	// getSchemaEntry returns the plugin's version.
+	memStore := storage.NewMemoryStore()
+	s, err := NewValidatorServiceWithStore(memStore)
+	require.NoError(t, err)
+	defer s.Close()
+
+	const storageSpec = `{"openapi":"3.0.0","info":{"title":"FromStorage","version":"0.9.0"},"paths":{}}`
+	const pluginSpec = `{"openapi":"3.0.0","info":{"title":"FromPlugin","version":"2.0.0"},"paths":{}}`
+
+	_, err = s.RegisterSchema(context.Background(), &pb.RegisterSchemaRequest{
+		SchemaId:      "pet-api",
+		SchemaContent: storageSpec,
+	})
+	require.NoError(t, err)
+	s.cache.Delete("pet-api") // force the miss path
+
+	rec := &recordingHooks{
+		fetchSchemaResp: &registrypb.FetchSchemaResponse{
+			Spec:            []byte(pluginSpec),
+			ResolvedVersion: "2.0.0",
+		},
+	}
+	s.SetHooks(rec)
+
+	entry, found := s.getSchemaEntry(context.Background(), "pet-api", "")
+	require.True(t, found)
+	require.NotNil(t, entry)
+	assert.Equal(t, "2.0.0", entry.Metadata.SchemaVersion, "plugin spec must win over storage")
+	assert.Equal(t, "FromPlugin", entry.Document.Info.Title)
+	require.Len(t, rec.fetchSchemaCalls, 1)
 }

--- a/server/cvtservice/validator_service.go
+++ b/server/cvtservice/validator_service.go
@@ -671,6 +671,16 @@ func (s *ValidatorService) getSchemaEntry(ctx context.Context, schemaID, version
 		return entry, true
 	}
 
+	// Cache miss — ask the fetch_schema plugin (if one is bound) before
+	// consulting storage. When a plugin is configured for this hook, it
+	// is the authoritative source; an error under fail_closed must NOT
+	// fall through to storage, or we'd silently contradict the plugin.
+	if entry, ok, err := s.tryFetchSchemaFromPlugin(ctx, schemaID, version); ok {
+		return entry, true
+	} else if err != nil {
+		return nil, false
+	}
+
 	// Cache miss — try storage
 	if s.store == nil {
 		return nil, false
@@ -758,6 +768,17 @@ func (s *ValidatorService) getSchemaEntry(ctx context.Context, schemaID, version
 func (s *ValidatorService) lookupPriorSchemaForCompat(ctx context.Context, schemaID string) (*SchemaEntry, bool, error) {
 	if entry, ok := s.cache.Get(schemaID); ok && entry != nil {
 		return entry, true, nil
+	}
+	// Compat check: when a fetch_schema plugin is bound, it is the
+	// authoritative source of truth for "what version is currently
+	// deployed" — the baseline for breaking-change detection must come
+	// from the plugin, not from whatever happens to be in local storage.
+	// Plugin errors propagate as-is so decision 1C (fail-closed on
+	// prior-version lookup) applies uniformly to storage and plugin.
+	if entry, ok, err := s.tryFetchSchemaFromPlugin(ctx, schemaID, ""); ok {
+		return entry, true, nil
+	} else if err != nil {
+		return nil, false, err
 	}
 	if s.store == nil {
 		return nil, false, nil


### PR DESCRIPTION
## Summary

Closes the last unwired v1 plugin hook. `fetch_schema` had SDK, proto, config surface, and adapter — but no core code path ever called `hooks.FetchSchema`. Docs described it as "declarative only; call site pending."

This wires it at the server's two schema-by-ID resolvers so a bound plugin is authoritative for every RPC that looks up a schema (`ValidateInteraction`, `GetSchema`, `CompareSchemas`, `CanIDeploy`, `RegisterConsumer`, `ListEndpoints`, `ValidateProducerResponse`, plus the `--check-compatibility` baseline).

## Design

- **Call site**: `server/cvtservice/getSchemaEntry` + `lookupPriorSchemaForCompat`. The design doc's pointer to `pkg/cvt/validator.go` is stale — that path has no cache/storage miss, so a plugin hop there would be meaningless. Corrected in this PR.
- **Ordering on cache miss**: plugin → storage. A bound plugin is the source of truth; fail_open collapses to storage fallback, fail_closed refuses the resolution (does not silently contradict the plugin).
- **New helper shape**: `tryFetchSchemaFromPlugin(ctx, id, version) (*SchemaEntry, bool, error)` — critical-path, uses caller's ctx, return value drives control flow. Different from the existing fire-and-forget `fireXxx` event helpers.
- **No write-through to `s.store`**: plugin is a fetch, not a registration. Mirroring would diverge two sources of truth.
- **Compat baseline**: `lookupPriorSchemaForCompat` wired too — otherwise breaking-change detection on `RegisterSchema --check-compatibility` would compare against local storage while `getSchemaEntry` returns the plugin's view, producing disagreement between "is this safe?" and "what's actually live?"

## Out of scope

- Issue #83 (the schema-by-ID rewrite). This wires the current `FetchSchema` proto as-is.
- Request-ID plumbing through schema resolution (not present server-side today; other hook fires also pass empty).
- Persisting plugin-supplied schemas into storage.

## Test plan

- [x] New unit tests in `server/cvtservice/hooks_fire_test.go`: no-hooks fallthrough, happy path caches bare key, versioned lookup writes versioned slot only, malformed spec logs+falls through, plugin error surfaces fail-closed, end-to-end ordering proved by populating storage with a different spec and showing the plugin's version is returned.
- [x] `go test ./server/... ./internal/... ./pkg/... -race` — all pass
- [x] `go build ./...` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `fetch_schema` plugin hook is now fully wired and operational, firing on schema cache misses before falling back to storage.

* **Documentation**
  * Updated plugin system documentation to reflect all four v1 hooks as now wired and active.
  * Clarified `fetch_schema` hook firing semantics and resolution behavior.

* **Tests**
  * Added comprehensive test coverage for schema fetching, caching, and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->