### PR TITLE
docs: full-scope audit + sync with current implementation

### DIFF
--- a/.claude/skills/docs-audit/references/sources-of-truth.md
+++ b/.claude/skills/docs-audit/references/sources-of-truth.md
@@ -61,7 +61,7 @@ This reference maps each audit scope to the implementation files that serve as t
 
 - **Command definitions**: `cmd/cvt/*.go` — each file defines a Cobra command with flags, args, and descriptions
 - **Main/root command**: `cmd/cvt/main.go` — root command registration and version info
-- **Commands**: validate.go, compare.go, generate.go, serve.go, can_i_deploy.go, wait.go, register_schema.go
+- **Commands**: validate.go, compare.go, generate.go, serve.go, can_i_deploy.go, wait.go, register_schema.go, mock.go, plugins.go, plugins_runtime.go
 - **Shared types**: `cmd/cvt/types.go` — shared CLI types and helpers
 - **Flag defaults**: Check `cmd.Flags().StringVar()`, `BoolVar()`, etc. calls for default values
 
@@ -83,7 +83,7 @@ This reference maps each audit scope to the implementation files that serve as t
 - Flag names, types, and defaults match
 - Command descriptions match
 - Output format examples are accurate
-- The 7 commands documented: validate, compare, generate, serve, can-i-deploy, wait, register-schema, version
+- The documented commands: validate, compare, generate, serve, can-i-deploy, wait, register-schema, mock, plugins, version
 
 ---
 
@@ -299,6 +299,11 @@ This reference maps each audit scope to the implementation files that serve as t
 - `docs/internal/prd.md` — Product requirements document
 - `docs/internal/adoption-strategy.md` — Internal adoption strategy
 - `docs/design/schema-inference.md` — Schema inference design
+- `docs/design/plugin-system.md` — Plugin system design
+- `docs/plugins/README.md` — Plugins overview
+- `docs/plugins/authoring-go.md` — Authoring plugins in Go
+- `docs/plugins/config.md` — Plugin config
+- `docs/plugins/reference-plugins.md` — Reference plugins
 
 ### Key checks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,18 @@ cvt serve --port 9550 --metrics-port 9551
 cvt serve --port 9550 --tls --cert server.crt --key server.key
 ```
 
+**plugins** - Manage CVT plugins (list, install, remove):
+
+```bash
+cvt plugins list                      # List installed plugins
+cvt plugins list --json               # JSON output
+cvt plugins install ./my-plugin       # Install a local plugin binary
+cvt plugins install <path> --name foo # Install under a specific name
+cvt plugins remove <name>             # Remove an installed plugin
+```
+
+Plugins live in `~/.cvt/plugins/` and are declared in `~/.cvt/config.yaml`. See `docs/plugins/` for the authoring guide.
+
 **version** - Show version information:
 
 ```bash

--- a/ci-templates/demo-producer.yml
+++ b/ci-templates/demo-producer.yml
@@ -83,7 +83,9 @@ env:
   #
   # CVT_API_KEY: ${{ secrets.CVT_API_KEY }}
   #
-  # The CVT CLI will automatically use this environment variable when set.
+  # Note: the CVT CLI does NOT auto-read CVT_API_KEY from the environment.
+  # Pass the key via gRPC metadata when using a language SDK (ContractValidator
+  # accepts an apiKey/api_key option in its constructor).
 
 jobs:
   producer-validation:

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -220,11 +220,14 @@ api/protos/plugin/
 
 pkg/cvt/
 ├── hooks.go                   # Hooks interface (no impl)
-└── validator.go               # two hook call sites
+├── hooks_fire.go              # fireOnValidationFailed helper
+└── validator.go               # on_validation_failed call site
 
 pkg/cvtplugin/                 # public SDK for plugin authors
 ├── doc.go
 ├── serve.go                   # wraps plugin.Serve with shared HandshakeConfig
+├── handshake.go               # shared HandshakeConfig constants
+├── handshake_service.go       # handshake plugin service wiring
 ├── registry.go                # Go interface for RegistryProvider authors
 ├── events.go                  # Go interface for EventHandler authors
 ├── logger.go                  # Zap-backed hclog adapter
@@ -234,7 +237,11 @@ internal/pluginclient/         # core-side typed adapters that implement pkg/cvt
 internal/pluginmgr/            # lifecycle via go-plugin, config load, audit wiring
 
 cmd/cvt/plugins.go             # list/install/remove
-server/cvtservice/             # post-split: consumer_registry.go, producer_validation.go host the two server-side hook call sites
+cmd/cvt/plugins_runtime.go     # runtime wiring when `cvt serve` loads configured plugins
+server/cvtservice/
+├── hooks_fire.go              # server-side hook helpers (on_breaking_change_detected, fetch_schema, on_consumer_registered)
+├── validator_service.go       # breaking-change + fetch_schema call sites
+└── consumer_registry.go       # on_consumer_registered call site
 ```
 
 ## Documentation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -345,6 +345,17 @@ mvn install
 
 ## Common Development Tasks
 
+### Running Linters
+
+```bash
+make lint           # All linters
+make lint-go        # golangci-lint on server/, pkg/, cmd/, sdks/go/
+make lint-node      # ESLint on sdks/node/
+make lint-python    # ruff on sdks/python/
+make lint-java      # Maven verify on sdks/java/
+make check-coverage # Enforce 80% coverage across all components
+```
+
 ### Running CI Checks Locally
 
 ```bash

--- a/docs/guides/producer-testing.mdx
+++ b/docs/guides/producer-testing.mdx
@@ -669,13 +669,13 @@ response, err := validator.GenerateResponse(ctx, "GET", "/pet/{petId}",
 
 ```java
 // Generate complete request/response fixture
-Fixture fixture = validator.generateFixture("GET", "/pet/{petId}");
+GeneratedFixture fixture = validator.generateFixture("GET", "/pet/{petId}", null);
 System.out.println(fixture.getRequest());   // { method, path, headers, body }
 System.out.println(fixture.getResponse());  // { statusCode, headers, body }
 
 // Generate response only with schema examples
-ResponseFixture response = validator.generateResponse("GET", "/pet/{petId}",
-    GenerateResponseOptions.builder()
+GeneratedResponse response = validator.generateResponse("GET", "/pet/{petId}",
+    GenerateOptions.builder()
         .statusCode(200)
         .useExamples(true)
         .build()

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -309,7 +309,7 @@ Set via `LOG_LEVEL` environment variable:
 {
   "level": "info",
   "ts": 1638360000.123,
-  "caller": "server/cvtservice/service.go:110",
+  "caller": "server/cvtservice/validator_service.go:110",
   "msg": "Schema registered successfully",
   "schemaId": "petstore-v3"
 }
@@ -317,7 +317,7 @@ Set via `LOG_LEVEL` environment variable:
 {
   "level": "info",
   "ts": 1638360001.456,
-  "caller": "server/cvtservice/service.go:237",
+  "caller": "server/cvtservice/validator_service.go:237",
   "msg": "Interaction validated successfully",
   "schemaId": "petstore-v3",
   "method": "POST",

--- a/docs/reference/architecture/consumer-registry.md
+++ b/docs/reference/architecture/consumer-registry.md
@@ -410,12 +410,15 @@ storage.UpdateConsumerValidation(
 │     └─────────────────────────────────────────────────────┘ │
 │                          │                                   │
 │                          ▼                                   │
-│  2. Register Consumer                                        │
+│  2. Register Consumer (via SDK or gRPC RegisterConsumer)     │
 │     ┌─────────────────────────────────────────────────────┐ │
-│     │ cvt register-consumer                               │ │
-│     │   --consumer order-service                          │ │
-│     │   --schema user-api                                 │ │
-│     │   --endpoints "GET /users/{id}"                     │ │
+│     │ await client.registerConsumer({                     │ │
+│     │   consumerId: 'order-service',                      │ │
+│     │   schemaId: 'user-api',                             │ │
+│     │   consumerVersion: '1.0.0',                         │ │
+│     │   environment: 'prod',                              │ │
+│     │   endpoints: [{ method: 'GET', path: '/users/{id}' }│ │
+│     │ });                                                 │ │
 │     └─────────────────────────────────────────────────────┘ │
 │                                                              │
 └─────────────────────────────────────────────────────────────┘
@@ -471,12 +474,12 @@ jobs:
 
       - name: Register Consumer
         if: github.ref == 'refs/heads/main'
-        run: |
-          cvt register-consumer \
-            --consumer ${{ github.repository }} \
-            --version ${{ github.sha }} \
-            --schema user-api \
-            --env prod
+        run: npm run register-consumer
+        env:
+          CVT_CONSUMER_ID: ${{ github.repository }}
+          CVT_CONSUMER_VERSION: ${{ github.sha }}
+          CVT_SCHEMA_ID: user-api
+          CVT_ENV: prod
 ```
 
 ```yaml

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -38,6 +38,7 @@ go install github.com/sahina/cvt/cmd/cvt@latest
 | `compare`         | Compare schemas for breaking changes                 |
 | `generate`        | Generate test fixtures from schemas                  |
 | `mock`            | Start a mock HTTP server from OpenAPI schemas        |
+| `plugins`         | Manage installed CVT plugins                         |
 | `register-schema` | Register an OpenAPI schema with the server           |
 | `serve`           | Start the server                                     |
 | `validate`        | Validate an interaction against a schema             |
@@ -447,6 +448,57 @@ cvt generate --schema ./openapi.json --method GET --path /pets/{petId} --seed 42
 | ---- | -------------------------------------- |
 | 0    | Server shut down cleanly               |
 | 1    | Failed to start (invalid schema, etc.) |
+
+---
+
+## plugins
+
+Manage installed CVT plugins. Plugin binaries live in `~/.cvt/plugins/` and are declared in `~/.cvt/config.yaml`.
+
+### Subcommands
+
+#### `plugins list`
+
+List installed plugins from `~/.cvt/plugins/state.json`.
+
+```bash
+cvt plugins list
+cvt plugins list --json   # Print state.json contents as JSON
+```
+
+| Flag     | Description                        | Default |
+| -------- | ---------------------------------- | ------- |
+| `--json` | Print state.json contents as JSON  | false   |
+
+#### `plugins install`
+
+Install a plugin binary into `~/.cvt/plugins/` and record its SHA256 in `state.json`.
+
+```bash
+cvt plugins install ./my-plugin-binary
+cvt plugins install ./cvt-plugin-registry-rest --name registry-rest
+```
+
+| Flag     | Description                                                                        | Default |
+| -------- | ---------------------------------------------------------------------------------- | ------- |
+| `--name` | Plugin name (defaults to binary basename with a leading `cvt-plugin-` stripped)    | derived |
+
+After install, add an entry under `plugins:` in `~/.cvt/config.yaml` and restart `cvt serve` so the plugin loads.
+
+#### `plugins remove`
+
+Remove an installed plugin binary and its state entry.
+
+```bash
+cvt plugins remove registry-rest
+```
+
+Takes the plugin name as a positional argument. After removal, also delete the plugin's entry from `~/.cvt/config.yaml`.
+
+### See also
+
+- [Plugin authoring guide](../plugins/authoring-go.md)
+- [Plugin config reference](../plugins/config.md)
 
 ---
 

--- a/docs/reference/sdk/go.md
+++ b/docs/reference/sdk/go.md
@@ -669,14 +669,15 @@ type GeneratedResponse struct {
 }
 
 type GeneratedFixture struct {
-    Request  GeneratedRequest
-    Response GeneratedResponse
+    Request  *GeneratedRequest
+    Response *GeneratedResponse
 }
 
 type EndpointInfo struct {
-    Method  string
-    Path    string
-    Summary string
+    Method      string
+    Path        string
+    OperationID string
+    Summary     string
 }
 
 type ConsumerImpact struct {

--- a/docs/reference/sdk/java.md
+++ b/docs/reference/sdk/java.md
@@ -610,6 +610,7 @@ public class GeneratedFixture {
 public class EndpointInfo {
     private String method;
     private String path;
+    private String operationId;
     private String summary;
 }
 

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -271,7 +271,7 @@ const result = await testKit.validateResponse({
 expect(result.valid).toBe(true);
 
 // Don't forget to close
-await testKit.close();
+testKit.close();
 ```
 
 ### Consumer Registry

--- a/server/README.md
+++ b/server/README.md
@@ -27,7 +27,13 @@ server/
 │   ├── validator_service.go   # Core validation service (RegisterSchema, ValidateInteraction, CanIDeploy)
 │   ├── compatibility_engine.go # Breaking change detection between schema versions
 │   ├── validation_utils.go    # Input validation utilities
-│   ├── cache.go               # Ristretto cache for schemas and consumers
+│   ├── cache.go               # Ristretto cache for OpenAPI schemas
+│   ├── consumer_registry.go   # Consumer registration and lookup
+│   ├── deployment_safety.go   # CanIDeploy and affected consumer analysis
+│   ├── fixture_generator.go   # Fixture generation from schemas
+│   ├── producer_validation.go # Producer-side response validation
+│   ├── hooks_fire.go          # Plugin hook dispatch
+│   ├── converters.go          # Proto/domain type conversion
 │   ├── health.go              # gRPC health check service
 │   ├── logger.go              # Structured logging with Zap
 │   ├── metrics.go             # Prometheus metrics


### PR DESCRIPTION
## Summary

Full-scope documentation audit (`/docs-audit` → `full`). Syncs docs with code for every sub-scope: project, cli, reference, sdk, getting-started, guides, ai-helper, operations, development, examples, internal/plugins, ci-templates.

### Key fixes

- **CLAUDE.md + `docs/reference/cli.mdx`** — add missing `plugins` command (list/install/remove)
- **`docs/reference/sdk/go.md` + `sdk/java.md`** — fix `GeneratedFixture` pointer types; add missing `OperationID`/`operationId` on `EndpointInfo`
- **`sdks/node/README.md`** — remove erroneous `await` on synchronous `testKit.close()`
- **`docs/guides/producer-testing.mdx`** — Java snippet used non-existent class names (`Fixture`, `ResponseFixture`, `GenerateResponseOptions`); fixed to `GeneratedFixture`/`GeneratedResponse`/`GenerateOptions`
- **`docs/reference/architecture/consumer-registry.md`** — replace fabricated `cvt register-consumer` CLI examples with real SDK/gRPC usage
- **`docs/design/plugin-system.md`** — rewrite code-layout block to match real file layout and hook call sites (post-split)
- **`server/README.md`** — add new `cvtservice/` files (consumer_registry, deployment_safety, fixture_generator, producer_validation, hooks_fire, converters), correct cache scope
- **`docs/operations/observability.md`** — fix caller paths (`service.go` → `validator_service.go`)
- **`ci-templates/demo-producer.yml`** — correct false claim that the CLI auto-reads `CVT_API_KEY`
- **`docs/development/contributing.md`** — document `make lint` / `make check-coverage` targets

### Skill self-update

Updated `.claude/skills/docs-audit/references/sources-of-truth.md` to include `mock`/`plugins` CLI commands and plugin docs under their scopes.

### Clean / no changes

All of: `README.md`, `CONTRIBUTING.md`, getting-started docs, ai-helper docs, `api.mdx`, `configuration.mdx`, most architecture docs, guides other than producer-testing, Python/Java/Go SDK READMEs, all 7 example READMEs, ci-templates README + Jenkinsfile + consumer + can-i-deploy workflows.

## Test plan

- [ ] Review each doc diff renders cleanly on docs site
- [ ] Verify plugin section in `cli.mdx` matches `cmd/cvt/plugins.go` flags
- [ ] Verify Java `EndpointInfo` / `GeneratedFixture` docs line up with current sources
- [ ] Spot-check consumer-registry diagram + CI example (no dangling `cvt register-consumer` refs)
- [ ] Confirm `sdks/go/README.md` "internal/development use" note is intentional (not touched in this PR — flagged in audit as needing human decision)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `plugins` CLI commands: `list`, `install`, and `remove` for plugin management.
  * Added `operationId` field to SDK endpoint metadata.

* **Documentation**
  * Expanded CLI and plugin documentation with management guides.
  * Updated SDK examples and contributing guidelines.
  * Clarified API key authentication in CI/CD workflows.

* **Bug Fixes**
  * Fixed fixture generation method signatures in Java SDK examples.
  * Corrected Node SDK test shutdown pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->