### PR TITLE
docs(site): add Plugin System, Mock Server, CI/CD feature cards

### DIFF
--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -62,7 +62,7 @@ const FeatureList: FeatureItem[] = [
     icon: '⊕',
     description:
       'Extend CVT with custom validators, fetchers, and lifecycle hooks. Go-based plugins installed via cvt plugins install.',
-    link: '/docs/plugins/authoring-go',
+    link: '/docs/plugins',
   },
   {
     title: 'Mock Server',

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -62,7 +62,7 @@ const FeatureList: FeatureItem[] = [
     icon: '⊕',
     description:
       'Extend CVT with custom validators, fetchers, and lifecycle hooks. Go-based plugins installed via cvt plugins install.',
-    link: '/docs/plugins/README',
+    link: '/docs/plugins/authoring-go',
   },
   {
     title: 'Mock Server',

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -57,6 +57,27 @@ const FeatureList: FeatureItem[] = [
       "CanIDeploy verification ensures schema changes won't break registered consumer contracts.",
     link: '/docs/guides/breaking-changes#deployment-safety-can-i-deploy',
   },
+  {
+    title: 'Plugin System',
+    icon: '⊕',
+    description:
+      'Extend CVT with custom validators, fetchers, and lifecycle hooks. Go-based plugins installed via cvt plugins install.',
+    link: '/docs/plugins/README',
+  },
+  {
+    title: 'Mock Server',
+    icon: '↯',
+    description:
+      'Spin up a mock HTTP server from any OpenAPI spec with cvt mock — request validation, latency simulation, and hot-reload built in.',
+    link: '/docs/reference/cli#mock',
+  },
+  {
+    title: 'CI/CD Integration',
+    icon: '⟳',
+    description:
+      'Drop-in templates and JSON output for GitHub Actions, GitLab, and Jenkins. Block PRs that introduce breaking changes.',
+    link: '/docs/guides/ci-cd-integration',
+  },
 ];
 
 type SDKExample = {


### PR DESCRIPTION
## Summary
- Adds three feature cards to the docs-site homepage: **Plugin System**, **Mock Server**, and **CI/CD Integration** — all previously shipped but not surfaced on the landing page.
- Fills out the feature grid to a clean 3x3 layout.
- All card links verified against existing pages in `docs/plugins/`, `docs/reference/cli.mdx`, and `docs/guides/ci-cd-integration.mdx`.

## Test plan
- [ ] Run docs-site dev server and confirm the 3 new cards render with correct copy and icons
- [ ] Click each new card and verify it navigates to the intended doc page