### PR TITLE
docs: layered rewrite — low-barrier getting-started, new CanIDeploy hub, plugin docs audit

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'guides/consumer-testing',
         'guides/producer-testing',
+        'guides/can-i-deploy',
         'guides/breaking-changes',
         'guides/validation-modes',
         'guides/ci-cd-integration',

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -55,7 +55,7 @@ const FeatureList: FeatureItem[] = [
     icon: '⊘',
     description:
       "CanIDeploy verification ensures schema changes won't break registered consumer contracts.",
-    link: '/docs/guides/breaking-changes#deployment-safety-can-i-deploy',
+    link: '/docs/guides/can-i-deploy',
   },
   {
     title: 'Plugin System',

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -239,9 +239,9 @@ internal/pluginmgr/            # lifecycle via go-plugin, config load, audit wir
 cmd/cvt/plugins.go             # list/install/remove
 cmd/cvt/plugins_runtime.go     # runtime wiring when `cvt serve` loads configured plugins
 server/cvtservice/
-├── hooks_fire.go              # server-side hook helpers (on_breaking_change_detected, fetch_schema, on_consumer_registered)
+├── hooks_fire.go              # server-side hook helpers (on_breaking_change_detected, fetch_schema, register_consumer_usage)
 ├── validator_service.go       # breaking-change + fetch_schema call sites
-└── consumer_registry.go       # on_consumer_registered call site
+└── consumer_registry.go       # register_consumer_usage call site
 ```
 
 ## Documentation

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -178,7 +178,8 @@ Every plugin call runs under a context deadline. On timeout, panic, or transport
 **Metrics** (Prometheus, existing `CVT_METRICS_PORT`):
 - `cvt_plugin_call_duration_seconds{plugin, service, method}` histogram.
 - `cvt_plugin_call_errors_total{plugin, service, method, code}` counter. `code` = canonical gRPC code name.
-- `cvt_plugin_up{plugin, version}` gauge.
+- `cvt_plugin_up{plugin}` gauge. Plugin-name only (version on `cvt_plugin_info`) so version bumps don't leak cardinality.
+- `cvt_plugin_info{plugin, version, sha256}` gauge. Always 1; carries reported identity; cleared on restart.
 - `cvt_plugin_restarts_total{plugin}` counter.
 
 **Audit:** `server/cvtservice/audit_logger.go` extended with plugin-call entries. Fields: `plugin`, `version`, `sha256`, `pid`, `request_id`, `service`, `method`, `duration_ms`, `outcome`, `error_code`. Secret config values redacted at emission. Writes are synchronous (small channel, block if full). Perf split deferred to v1.1 if it matters.

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -9,6 +9,16 @@ description: Non-obvious questions about CVT
 
 No. CVT is a test-time tool — the server runs in CI or on your local machine during development. Your production services never talk to it. Think of it like a test database: it exists to support your test suite, not your live traffic.
 
+## Do I need both consumer tests *and* producer tests?
+
+You need one side at minimum. You need both to get the full value.
+
+- **Consumer tests alone** catch your own integration bugs — you're calling the API in a way the spec allows.
+- **Producer tests alone** catch your own implementation drift — your handlers return what the spec promises.
+- **Both together** — plus consumer registration — enable [`can-i-deploy`](../guides/can-i-deploy.mdx), which blocks the producer's breaking changes before they reach any registered consumer. That's the payoff.
+
+In practice: if you own an API, you write producer tests. If you call someone else's API, you write consumer tests. In a microservice stack, most services end up doing both (they consume some APIs and produce others).
+
 ## How is this different from Pact?
 
 Pact is broker-centric and generates contracts from recorded interactions. CVT is schema-first — you bring an existing OpenAPI spec and validate against it directly. There's no broker to host, no contract generation step, and consumers don't need to coordinate with producers during test authoring. If you already have OpenAPI specs (most teams do), CVT lets you use them as the contract without an additional layer.
@@ -38,7 +48,7 @@ This is sometimes called "provider-generated stubs." The key advantage is that t
 | Go       | `NewMockClient()`       | `http.Client`        |
 | Java     | `MockInterceptor`       | OkHttp `Interceptor` |
 
-See [Approach 3: Mock Client](../guides/consumer-testing.mdx#approach-3-mock-client) in the Consumer Testing Guide for full setup examples.
+See [Approach 3 — Mock adapter](../guides/consumer-testing.mdx#approach-3--mock-adapter-no-real-api-needed) in the Consumer Testing Guide for full setup examples.
 
 ## Are CVT mock adapters a full mock server?
 
@@ -59,7 +69,7 @@ For automated testing, the in-process mock adapters remain the recommended appro
 
 Mock responses are structurally correct — they match the schema's types, required fields, and response codes — but they don't capture business logic. A mock for `GET /pet/123` will return a valid pet object, but it won't know that pet 123 is a dog named Max.
 
-This is by design. Mock adapters solve the "does my consumer code handle the response shape correctly?" question. For **"does the producer actually behave this way?"** you need [producer testing](../guides/producer-testing.mdx#schema-compliance-testing) and [contract validation](../guides/consumer-testing.mdx#approach-2-http-adapter-recommended).
+This is by design. Mock adapters solve the "does my consumer code handle the response shape correctly?" question. For **"does the producer actually behave this way?"** you need [producer testing](../guides/producer-testing.mdx#schema-compliance-testing) and [contract validation](../guides/consumer-testing.mdx#approach-2--http-adapter-recommended-for-existing-tests).
 
 The combination is powerful: mock adapters give consumers fast, offline feedback during development, and contract validation catches real integration issues in CI. Neither replaces the other.
 
@@ -69,4 +79,4 @@ For some workflows, yes:
 
 - **CLI offline commands** (**server not needed**) — [`cvt validate`](../reference/cli.mdx#validate), [`cvt compare`](../reference/cli.mdx#compare), [`cvt generate`](../reference/cli.mdx#generate), and [`cvt mock`](../reference/cli.mdx#mock) work without a CVT server. They operate on local schema files directly (or fetch from a URL if one is provided).
 - **Embedded Go library** (**server not needed**) — [`pkg/cvt`](https://pkg.go.dev/github.com/sahina/cvt/pkg/cvt) can be imported directly into Go code for in-process validation without any network calls.
-- **SDK-based workflow** (**server needed**) — [`registerSchema`](../reference/sdk/index.mdx#initialization), [`validate`](../reference/sdk/index.mdx#validation), [consumer registration](../guides/consumer-testing.mdx), and [`can-i-deploy`](../reference/cli.mdx#can-i-deploy) require a running server since SDKs communicate over [gRPC](../reference/api.mdx#service-methods).
+- **SDK-based workflow** (**server needed**) — [`registerSchema`](../reference/sdk/index.mdx#initialization), [`validate`](../reference/sdk/index.mdx#validation), [consumer registration](../guides/consumer-testing.mdx#consumer-registration), and [`can-i-deploy`](../guides/can-i-deploy.mdx) require a running server since SDKs communicate over [gRPC](../reference/api.mdx#service-methods).

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -10,49 +10,58 @@ import TabItem from "@theme/TabItem";
 
 # Installation
 
-This guide covers installing the CVT server and client SDKs.
+Two things to install: the **CVT server** (one per shared environment) and an **SDK** for your service's language. In most team setups the platform team runs the server once; individual services only install SDKs.
 
-## Server Installation
-
-### Docker (Recommended)
-
-The easiest way to run CVT is with Docker:
+## Server
 
 ```bash
-# Run the published Docker image directly
 docker run -d -p 9550:9550 -p 9551:9551 ghcr.io/sahina/cvt:latest
 ```
 
-### From Source
-
-Build and run the server locally:
+Verify it's up:
 
 ```bash
-# Clone the repository
+curl http://localhost:9551/metrics
+# Should return Prometheus metrics
+```
+
+<details>
+<summary>Other ways to run the server (source, Docker Compose, go install)</summary>
+
+**From source** — clone and build locally (useful for contributors):
+
+```bash
 git clone https://github.com/sahina/cvt.git
 cd cvt
-
-# Build the server
 make build
-
-# Run locally
 make run-server
+```
 
-# Using Docker Compose (if you cloned the repo. includes observability stack)
+**Docker Compose** — includes the observability stack (Prometheus + Grafana):
+
+```bash
+cd cvt
 make up
 ```
 
-### Go Install
+**go install** — if you have a Go toolchain:
 
 ```bash
 go install github.com/sahina/cvt/cmd/cvt@latest
 ```
 
+**gRPC health probe** — for the `make health` target or Kubernetes readiness checks:
+
+```bash
+go install github.com/grpc-ecosystem/grpc-health-probe@latest
+grpc-health-probe -addr=localhost:9550
+```
+
+</details>
+
 ---
 
-## SDK Installation
-
-Install the SDK for your language:
+## SDK
 
 <Tabs groupId="sdk-language">
   <TabItem value="nodejs" label="Node.js" default>
@@ -61,14 +70,22 @@ Install the SDK for your language:
 npm install @sahina/cvt-sdk
 ```
 
+```typescript
+import { ContractValidator } from "@sahina/cvt-sdk";
+const validator = new ContractValidator("localhost:9550");
+```
+
   </TabItem>
   <TabItem value="python" label="Python">
 
 ```bash
 pip install cvt-sdk
+# or: uv add cvt-sdk
+```
 
-# Or with uv
-uv add cvt-sdk
+```python
+from cvt_sdk import ContractValidator
+validator = ContractValidator("localhost:9550")
 ```
 
   </TabItem>
@@ -78,120 +95,57 @@ uv add cvt-sdk
 go get github.com/sahina/cvt/sdks/go
 ```
 
+```go
+import "github.com/sahina/cvt/sdks/go/cvt"
+client, err := cvt.NewValidator("localhost:9550")
+```
+
   </TabItem>
   <TabItem value="java" label="Java">
 
-**Maven** (`pom.xml`):
+**Maven** — add to `pom.xml`:
 
 ```xml
 <dependency>
     <groupId>io.github.sahina</groupId>
     <artifactId>cvt-sdk</artifactId>
-    <version>0.1.3</version> <!-- Replace with latest from Maven Central -->
+    <version>0.1.3</version>
 </dependency>
 ```
 
-**Gradle** (`build.gradle`):
+**Gradle** — add to `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation("io.github.sahina:cvt-sdk:0.1.3") // Replace with latest from Maven Central
+    implementation("io.github.sahina:cvt-sdk:0.1.3")
 }
 ```
-
-Find the latest version on [Maven Central](https://central.sonatype.com/artifact/io.github.sahina/cvt-sdk).
-
-  </TabItem>
-</Tabs>
-
----
-
-## Verify Installation
-
-### Check Server
-
-```bash
-# Check metrics endpoint (no extra tools required)
-curl http://localhost:9551/metrics
-```
-
-#### Using grpc-health-probe (Optional)
-
-The `make health` command and direct health checks require [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) to be installed:
-
-```bash
-# Install grpc-health-probe
-go install github.com/grpc-ecosystem/grpc-health-probe@latest
-
-# Then you can run health checks
-make health
-
-# Or directly
-grpc-health-probe -addr=localhost:9550
-```
-
-### Check SDK
-
-<Tabs groupId="sdk-language">
-  <TabItem value="nodejs" label="Node.js" default>
-
-```typescript
-import { ContractValidator } from "@sahina/cvt-sdk";
-const validator = new ContractValidator("localhost:9550");
-console.log("Connected!");
-```
-
-  </TabItem>
-  <TabItem value="python" label="Python">
-
-```python
-from cvt_sdk import ContractValidator
-validator = ContractValidator('localhost:9550')
-print('Connected!')
-```
-
-  </TabItem>
-  <TabItem value="go" label="Go">
-
-```go
-import "github.com/sahina/cvt/sdks/go/cvt"
-
-client, err := cvt.NewValidator("localhost:9550")
-if err != nil {
-    log.Fatalf("Failed to connect: %v", err)
-}
-fmt.Println("Connected!")
-```
-
-  </TabItem>
-  <TabItem value="java" label="Java">
 
 ```java
 import io.github.sahina.sdk.ContractValidator;
-
 ContractValidator validator = new ContractValidator("localhost:9550");
-System.out.println("Connected!");
 ```
+
+Latest version: [Maven Central](https://central.sonatype.com/artifact/io.github.sahina/cvt-sdk).
 
   </TabItem>
 </Tabs>
 
 ---
 
-## Port Configuration
+## Next
 
-| Port | Service                                  |
-| ---- | ---------------------------------------- |
-| 9550 | gRPC server                              |
-| 9551 | Prometheus metrics                       |
-| 9091 | Prometheus UI (with observability stack) |
-| 3000 | Grafana UI (with observability stack)    |
+- **[Quick Start](./quick-start.mdx)** — write your first contract test in 5 minutes.
+- **[Configuration Reference](../reference/configuration.mdx)** — TLS, auth, persistent storage, all server settings.
 
----
+<details>
+<summary>Port reference</summary>
 
-## Next Steps
+| Port | Service |
+|---|---|
+| 9550 | gRPC server |
+| 9551 | Prometheus metrics |
+| 9091 | Prometheus UI (observability stack) |
+| 3000 | Grafana UI (observability stack) |
 
-- **[Quick Start](./quick-start.mdx)** - Your first contract test
-- **[Consumer Testing Guide](../guides/consumer-testing.mdx)** - Test API integrations
-- **[Producer Testing Guide](../guides/producer-testing.mdx)** - Validate your APIs
-- **[Configuration Reference](../reference/configuration.mdx)** - Server settings
+</details>

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -428,6 +428,6 @@ await validator.registerConsumer({
 });
 ```
 
-This is how CVT knows to block Bob's breaking change before it reaches you. See [CanIDeploy](../guides/breaking-changes.mdx#deployment-safety-can-i-deploy).
+This is how CVT knows to block Bob's breaking change before it reaches you. See [CanIDeploy](../guides/can-i-deploy.mdx).
 
 </details>

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -8,73 +8,109 @@ description: Your first contract test in 5 minutes
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Quick Start
+# Quick Start: validate your first API call
 
-This guide walks you through your first contract test in under 5 minutes.
+You'll write one test that proves your service calls the Pets API correctly. New to CVT? Read the [Introduction](../intro.md) first — it explains Alice, Bob, and why this matters in 2 minutes.
 
-## Prerequisites
+:::info Assumes a running CVT server
+The examples assume CVT is reachable at `localhost:9550`. No server yet? See [Installation](./installation.mdx) (`docker run -d -p 9550:9550 ghcr.io/sahina/cvt:latest` is the short version).
 
-- CVT server running (see [Installation](./installation.mdx))
-- An OpenAPI schema to test against (we'll use the included Petstore schema)
-
-You can either:
-
-- Save the [Petstore OpenAPI schema](https://petstore3.swagger.io/api/v3/openapi.json) as `./openapi.json` in your project directory, OR
-- Use the URL directly: `https://petstore3.swagger.io/api/v3/openapi.json`
-
-All `registerSchema` methods accept both file paths and URLs. The examples below use a local file path, but you can substitute a URL.
-
-## Step 1: Start the Server
-
-```bash
-# Using the published Docker image (recommended)
-docker run -d -p 9550:9550 -p 9551:9551 ghcr.io/sahina/cvt:latest
-
-# Or using Docker Compose (if you've cloned the repository)
-make up
-
-# Or build and run locally
-make run-server
-```
-
-Verify it's running:
-
-```bash
-curl http://localhost:9551/metrics
-# Should return Prometheus metrics
-```
-
-:::info Producer vs Consumer
-In a team environment, the **producer** (API owner) registers their OpenAPI schema with the shared CVT server, and **consumers** validate against it. In this Quick Start, we combine both steps for simplicity. See the [CI/CD Integration Guide](../guides/ci-cd-integration.mdx#recommended-workflow) for the recommended production workflow.
+Save the [Petstore OpenAPI schema](https://petstore3.swagger.io/api/v3/openapi.json) as `./openapi.json` in your project, or pass the URL directly to `registerSchema`.
 :::
 
-## Step 2: Create a Simple Test
+## TL;DR
 
-<Tabs groupId="language">
-  <TabItem value="nodejs" label="Node.js" default>
-
-Create a test file `contract.test.ts`:
+The whole interaction in 20 lines of TypeScript:
 
 ```typescript
 import { ContractValidator } from "@sahina/cvt-sdk";
-import * as path from "path";
 
-describe("Petstore API Contract", () => {
+const validator = new ContractValidator("localhost:9550");
+await validator.registerSchema("petstore", "./openapi.json");
+
+const result = await validator.validate(
+  { method: "GET", path: "/pet/123" },
+  {
+    statusCode: 200,
+    body: {
+      id: 123,
+      name: "doggie",
+      photoUrls: ["https://example.com/photo.jpg"],
+      status: "available",
+    },
+  },
+);
+
+console.log(result.valid); // true
+validator.close();
+```
+
+The rest of this page turns that into a real test file, runs it, and shows what a failure looks like.
+
+## Step 1: install the SDK
+
+<Tabs groupId="sdk-language">
+  <TabItem value="nodejs" label="Node.js" default>
+
+```bash
+npm install @sahina/cvt-sdk
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```bash
+pip install cvt-sdk
+```
+
+  </TabItem>
+  <TabItem value="go" label="Go">
+
+```bash
+go get github.com/sahina/cvt/sdks/go
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>io.github.sahina</groupId>
+    <artifactId>cvt-sdk</artifactId>
+    <version>0.1.3</version>
+</dependency>
+```
+
+Full install options (including Gradle): [Installation](./installation.mdx).
+
+  </TabItem>
+</Tabs>
+
+## Step 2: write the test
+
+One file, two test cases: a valid response (passes) and a response missing required fields (fails).
+
+<Tabs groupId="sdk-language">
+  <TabItem value="nodejs" label="Node.js" default>
+
+`contract.test.ts`:
+
+```typescript
+import { ContractValidator } from "@sahina/cvt-sdk";
+
+describe("Pets API contract", () => {
   let validator: ContractValidator;
 
   beforeAll(async () => {
     validator = new ContractValidator("localhost:9550");
-
-    // Register the Petstore schema from file
-    const schemaPath = path.resolve(__dirname, "./openapi.json");
-    await validator.registerSchema("petstore", schemaPath);
-    // Or register from URL:
-    // await validator.registerSchema('petstore', 'https://petstore3.swagger.io/api/v3/openapi.json');
+    await validator.registerSchema("petstore", "./openapi.json");
   });
 
   afterAll(() => validator.close());
 
-  it("validates a correct pet response", async () => {
+  it("passes for a well-formed pet response", async () => {
     const result = await validator.validate(
       { method: "GET", path: "/pet/123" },
       {
@@ -91,12 +127,12 @@ describe("Petstore API Contract", () => {
     expect(result.valid).toBe(true);
   });
 
-  it("catches invalid responses", async () => {
+  it("fails when required fields are missing", async () => {
     const result = await validator.validate(
       { method: "GET", path: "/pet/123" },
       {
         statusCode: 200,
-        body: { id: 123 }, // missing required 'name' and 'photoUrls' fields
+        body: { id: 123 }, // no `name`, no `photoUrls`
       },
     );
 
@@ -106,16 +142,10 @@ describe("Petstore API Contract", () => {
 });
 ```
 
-Run the test:
-
-```bash
-npm test
-```
-
   </TabItem>
   <TabItem value="python" label="Python">
 
-Create a test file `test_contract.py`:
+`test_contract.py`:
 
 ```python
 import pytest
@@ -124,55 +154,44 @@ from cvt_sdk import ContractValidator
 
 @pytest.fixture(scope="module")
 def validator():
-    v = ContractValidator('localhost:9550')
-
-    # Register the Petstore schema from file
-    v.register_schema('petstore', './openapi.json')
-    # Or register from URL:
-    # v.register_schema('petstore', 'https://petstore3.swagger.io/api/v3/openapi.json')
-
+    v = ContractValidator("localhost:9550")
+    v.register_schema("petstore", "./openapi.json")
     yield v
     v.close()
 
 
-def test_validates_correct_pet_response(validator):
+def test_passes_for_well_formed_pet_response(validator):
     result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/123'},
+        request={"method": "GET", "path": "/pet/123"},
         response={
-            'status_code': 200,
-            'body': {
-                'id': 123,
-                'name': 'doggie',
-                'photoUrls': ['https://example.com/photo.jpg'],
-                'status': 'available'
-            }
-        }
+            "status_code": 200,
+            "body": {
+                "id": 123,
+                "name": "doggie",
+                "photoUrls": ["https://example.com/photo.jpg"],
+                "status": "available",
+            },
+        },
     )
     assert result["valid"] is True
 
 
-def test_catches_invalid_responses(validator):
+def test_fails_when_required_fields_are_missing(validator):
     result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/123'},
+        request={"method": "GET", "path": "/pet/123"},
         response={
-            'status_code': 200,
-            'body': {'id': 123}  # missing required 'name' and 'photoUrls' fields
-        }
+            "status_code": 200,
+            "body": {"id": 123},  # no `name`, no `photoUrls`
+        },
     )
     assert result["valid"] is False
     assert len(result["errors"]) > 0
 ```
 
-Run the test:
-
-```bash
-pytest test_contract.py -v
-```
-
   </TabItem>
   <TabItem value="go" label="Go">
 
-Create a test file `contract_test.go`:
+`contract_test.go`:
 
 ```go
 package main
@@ -186,19 +205,16 @@ import (
     "github.com/stretchr/testify/require"
 )
 
-func TestPetstoreAPIContract(t *testing.T) {
+func TestPetsAPIContract(t *testing.T) {
     ctx := context.Background()
     validator, err := cvt.NewValidator("localhost:9550")
     require.NoError(t, err)
     defer validator.Close()
 
-    // Register the Petstore schema from file
     err = validator.RegisterSchema(ctx, "petstore", "./openapi.json")
-    // Or register from URL:
-    // err = validator.RegisterSchema(ctx, "petstore", "https://petstore3.swagger.io/api/v3/openapi.json")
     require.NoError(t, err)
 
-    t.Run("validates correct pet response", func(t *testing.T) {
+    t.Run("passes for a well-formed pet response", func(t *testing.T) {
         result, err := validator.Validate(ctx,
             cvt.ValidationRequest{Method: "GET", Path: "/pet/123"},
             cvt.ValidationResponse{
@@ -215,12 +231,12 @@ func TestPetstoreAPIContract(t *testing.T) {
         assert.True(t, result.Valid)
     })
 
-    t.Run("catches invalid responses", func(t *testing.T) {
+    t.Run("fails when required fields are missing", func(t *testing.T) {
         result, err := validator.Validate(ctx,
             cvt.ValidationRequest{Method: "GET", Path: "/pet/123"},
             cvt.ValidationResponse{
                 StatusCode: 200,
-                Body:       map[string]any{"id": 123}, // missing required 'name' and 'photoUrls'
+                Body:       map[string]any{"id": 123}, // no `name`, no `photoUrls`
             },
         )
         require.NoError(t, err)
@@ -230,41 +246,27 @@ func TestPetstoreAPIContract(t *testing.T) {
 }
 ```
 
-Run the test:
-
-```bash
-go test -v
-```
-
   </TabItem>
   <TabItem value="java" label="Java">
 
-Create a test file `ContractTest.java`:
+`PetsAPIContractTest.java`:
 
 ```java
-package com.example;
-
 import io.github.sahina.sdk.ContractValidator;
 import io.github.sahina.sdk.ValidationRequest;
 import io.github.sahina.sdk.ValidationResponse;
 import io.github.sahina.sdk.ValidationResult;
 import org.junit.jupiter.api.*;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-class PetstoreAPIContractTest {
+class PetsAPIContractTest {
     private static ContractValidator validator;
 
     @BeforeAll
-    static void setup() throws IOException {
+    static void setup() throws Exception {
         validator = new ContractValidator("localhost:9550");
-
-        // Register the Petstore schema from file
         validator.registerSchema("petstore", "./openapi.json");
-        // Or register from URL:
-        // validator.registerSchema("petstore", "https://petstore3.swagger.io/api/v3/openapi.json");
     }
 
     @AfterAll
@@ -273,43 +275,64 @@ class PetstoreAPIContractTest {
     }
 
     @Test
-    void validatesCorrectPetResponse() {
+    void passesForWellFormedPetResponse() {
         ValidationRequest request = ValidationRequest.builder()
-                .method("GET")
-                .path("/pet/123")
-                .build();
+                .method("GET").path("/pet/123").build();
 
         ValidationResponse response = ValidationResponse.builder()
                 .statusCode(200)
-                .body("{\"id\": 123, \"name\": \"doggie\", \"photoUrls\": [\"https://example.com/photo.jpg\"], \"status\": \"available\"}")
+                .body("{\"id\":123,\"name\":\"doggie\",\"photoUrls\":[\"https://example.com/photo.jpg\"],\"status\":\"available\"}")
                 .build();
 
         ValidationResult result = validator.validate(request, response);
-
         assertTrue(result.isValid());
     }
 
     @Test
-    void catchesInvalidResponses() {
+    void failsWhenRequiredFieldsAreMissing() {
         ValidationRequest request = ValidationRequest.builder()
-                .method("GET")
-                .path("/pet/123")
-                .build();
+                .method("GET").path("/pet/123").build();
 
         ValidationResponse response = ValidationResponse.builder()
                 .statusCode(200)
-                .body("{\"id\": 123}")  // missing required 'name' and 'photoUrls' fields
+                .body("{\"id\":123}")  // no `name`, no `photoUrls`
                 .build();
 
         ValidationResult result = validator.validate(request, response);
-
         assertFalse(result.isValid());
         assertFalse(result.getErrors().isEmpty());
     }
 }
 ```
 
-Run the test:
+  </TabItem>
+</Tabs>
+
+## Step 3: run it
+
+<Tabs groupId="sdk-language">
+  <TabItem value="nodejs" label="Node.js" default>
+
+```bash
+npm test
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```bash
+pytest test_contract.py -v
+```
+
+  </TabItem>
+  <TabItem value="go" label="Go">
+
+```bash
+go test -v
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
 
 ```bash
 mvn test
@@ -318,101 +341,79 @@ mvn test
   </TabItem>
 </Tabs>
 
-## Step 3: Use the CLI
+Both tests should pass:
 
-For quick validations without code:
+- The **first** test sends a well-formed pet response; CVT confirms it matches the schema.
+- The **second** test sends a malformed response missing `name` and `photoUrls`; CVT reports the required-field violations, and the test asserts that failure.
 
-```bash
-# Build the CLI
-go build -o cvt ./cmd/cvt
+That second test is the point. Your contract test now catches schema violations *before* they ship — exactly what would have saved Alice from last Tuesday's outage.
 
-# Create request and response files
-cat > request.json << 'EOF'
-{
-  "method": "GET",
-  "path": "/pet/123"
-}
-EOF
+## What you just did
 
-cat > response.json << 'EOF'
-{
-  "status_code": 200,
-  "body": "{\"id\": 123, \"name\": \"doggie\", \"photoUrls\": [\"https://example.com/photo.jpg\"], \"status\": \"available\"}"
-}
-EOF
+You proved that your code calls the Pets API in a way Bob's spec promises is valid. This is the **consumer half** of contract testing.
 
-# Validate the interaction
-cvt validate --schema openapi.json --request request.json --response response.json
-```
+The other half is on Bob's side: he verifies his handlers actually *return* what his spec promises. That's what makes `can-i-deploy` trustworthy later.
 
-### Mock Server
+## Other ways to validate
 
-Start a mock HTTP server from any OpenAPI schema — useful for frontend development, manual testing, or mocking upstream APIs:
+The explicit `validate()` call you just used is the simplest approach. CVT supports two more — each trades off setup complexity against coverage:
 
-```bash
-# Start mock server on port 8080
-cvt mock --schema openapi.json
+| Approach | How it works | When to use |
+|---|---|---|
+| **Direct `validate()`** (this quickstart) | Call `validator.validate(request, response)` per interaction | Learning CVT; validating a handful of specific calls |
+| **HTTP adapter** | Wrap your HTTP client (axios, requests, OkHttp…) so every call is validated automatically | Existing integration tests; no per-call changes |
+| **Mock adapter** | Skip the real API; CVT generates spec-compliant responses in-process | Unit tests; offline/fast feedback; frontend dev |
 
-# With request validation and hot-reload
-cvt mock --schema openapi.json --validate-requests --watch
+Full walkthrough of all three: [Consumer Testing Guide](../guides/consumer-testing.mdx).
 
-# Test it
-curl http://localhost:8080/pet/123
-```
+**Producing an API instead?** The [Producer Testing Guide](../guides/producer-testing.mdx) covers schema-compliance tests, middleware modes (strict / warn / shadow), and full HTTP integration.
 
-See the [CLI Reference](../reference/cli.mdx#mock) for all mock server options.
+→ Keep going: **[Consumer Testing Guide](../guides/consumer-testing.mdx)** (Alice's deeper walkthrough) or **[Producer Testing Guide](../guides/producer-testing.mdx)** (Bob's side).
 
-## What's Next?
+<details>
+<summary>Why register the schema if I'm just validating one call?</summary>
 
-Now that you've validated your first interaction, explore:
+`registerSchema` caches Bob's contract on the CVT server. Subsequent `validate` calls are fast lookups — no re-parse of the OpenAPI spec. It's idempotent: calling it with the same ID and content is a no-op. Most teams register once in `beforeAll`.
 
-- **[Consumer Testing Guide](../guides/consumer-testing.mdx)** - Test your API integrations
-- **[Producer Testing Guide](../guides/producer-testing.mdx)** - Validate your API implementations
-- **[Breaking Changes Guide](../guides/breaking-changes.mdx)** - Detect schema incompatibilities
-- **[SDK Reference](../reference/sdk/)** - Language-specific features
+In a real team setup, **Bob's CI registers the schema**, not Alice's tests. The call in this quickstart is a shortcut for local development. See [Consumer Testing Guide](../guides/consumer-testing.mdx) for the production pattern.
 
-## Common Patterns
+</details>
 
-### Loading Schema from URL
+<details>
+<summary>Validating from a URL instead of a file</summary>
+
+`registerSchema` accepts either a local path or an HTTP(S) URL. Useful when the spec is published as a build artifact or served by the producer's CI:
 
 ```typescript
-// Register schema directly from URL
 await validator.registerSchema(
   "petstore",
   "https://petstore3.swagger.io/api/v3/openapi.json",
 );
 ```
 
-### Using HTTP Adapters
+</details>
 
-Automatically validate all HTTP traffic:
+<details>
+<summary>No SDK? Use the `cvt` CLI</summary>
 
-```typescript
-import axios from "axios";
-import { createAxiosAdapter } from "@sahina/cvt-sdk/adapters";
+The CLI runs the same validation without any code, handy for bash scripts or smoke tests:
 
-const api = axios.create({ baseURL: "http://api.example.com" });
-const adapter = createAxiosAdapter({
-  axios: api,
-  validator,
-  autoValidate: true,
-});
-
-// All requests/responses are now validated automatically
-const pet = await api.get("/pet/123");
-
-// Check validation results
-const interactions = adapter.getInteractions();
-console.log(interactions[0].validationResult?.valid);
+```bash
+cvt validate --schema ./openapi.json --request request.json --response response.json
 ```
 
-### Registering as a Consumer
+Full CLI options: [CLI Reference](../reference/cli.mdx#validate). For a running mock HTTP server (frontend dev, manual testing): [`cvt mock`](../reference/cli.mdx#mock).
 
-Enable deployment safety checks:
+</details>
+
+<details>
+<summary>Registering your service as a consumer (needed for can-i-deploy)</summary>
+
+After your contract tests pass, register your service as a consumer so Bob's `can-i-deploy` check can see you:
 
 ```typescript
 await validator.registerConsumer({
-  consumerId: "my-service",
+  consumerId: "checkout-service",
   consumerVersion: "1.0.0",
   schemaId: "petstore",
   schemaVersion: "1.0.0",
@@ -426,3 +427,7 @@ await validator.registerConsumer({
   ],
 });
 ```
+
+This is how CVT knows to block Bob's breaking change before it reaches you. See [CanIDeploy](../guides/breaking-changes.mdx#deployment-safety-can-i-deploy).
+
+</details>

--- a/docs/guides/breaking-changes.mdx
+++ b/docs/guides/breaking-changes.mdx
@@ -1,8 +1,8 @@
 ---
 title: Breaking Changes Guide
 sidebar_label: Breaking Changes
-sidebar_position: 4
-description: Understanding and detecting breaking changes in API schemas
+sidebar_position: 5
+description: Detect breaking changes in API schemas with cvt compare
 ---
 
 import Tabs from "@theme/Tabs";
@@ -10,51 +10,53 @@ import TabItem from "@theme/TabItem";
 
 # Breaking Changes Guide
 
-This guide covers how CVT detects breaking changes between API schema versions and how to use the `can-i-deploy` safety check.
+This page covers detecting breaking changes between two versions of an OpenAPI spec. For using breaking-change detection as a deploy gate, see **[CanIDeploy](./can-i-deploy.mdx)**.
 
-## What Are Breaking Changes?
-
-Breaking changes are modifications to an API that can cause existing consumers to fail. CVT detects these automatically when comparing schema versions.
-
-### Types of Breaking Changes
-
-| Type                       | Description                          | Example                                    |
-| -------------------------- | ------------------------------------ | ------------------------------------------ |
-| `ENDPOINT_REMOVED`         | An endpoint was removed              | `DELETE /pet/{petId}` no longer exists     |
-| `REQUIRED_FIELD_ADDED`     | A new required field in request body | Request now requires `category` field      |
-| `REQUIRED_PARAMETER_ADDED` | New required query/path/header param | `?apiVersion` now required                 |
-| `TYPE_CHANGED`             | Field type changed incompatibly      | `id` changed from `integer` to `string`    |
-| `RESPONSE_SCHEMA_CHANGED`  | Response structure changed           | Response no longer includes `status` field |
-| `ENUM_VALUE_REMOVED`       | Enum value was removed               | `status` no longer accepts `"pending"`     |
-
-### Non-Breaking Changes
-
-These changes are safe for existing consumers:
-
-| Change                     | Why It's Safe                          |
-| -------------------------- | -------------------------------------- |
-| Adding optional fields     | Consumers can ignore them              |
-| Adding new endpoints       | Existing calls aren't affected         |
-| Adding optional parameters | Existing calls work without them       |
-| Adding enum values         | Existing values still work             |
-| Relaxing validation        | Previously valid requests remain valid |
-| Improving descriptions     | Documentation-only                     |
-
----
-
-## Schema Comparison
-
-### Using the CLI
+## TL;DR
 
 ```bash
-# Compare two schema files
 cvt compare --old ./v1/openapi.json --new ./v2/openapi.json
-
-# JSON output for scripting
-cvt compare --old ./v1/openapi.json --new ./v2/openapi.json --json
 ```
 
-### Output Example
+Output lists every breaking change with type, location, and description. Exit `0` on compatible, `1` on breaking — drop it into a PR check.
+
+## What are breaking changes?
+
+A breaking change is any schema modification that would make an existing caller fail. CVT detects these automatically.
+
+### Types CVT flags as breaking
+
+| Type | Description | Example |
+|---|---|---|
+| `ENDPOINT_REMOVED` | Endpoint no longer exists | `DELETE /pet/{petId}` was removed |
+| `REQUIRED_FIELD_ADDED` | New required field in request body | POST `/pet` now requires `category` |
+| `REQUIRED_PARAMETER_ADDED` | New required query/path/header param | `?apiVersion` now required |
+| `TYPE_CHANGED` | Field type changed incompatibly | `id` changed from `integer` to `string` |
+| `RESPONSE_SCHEMA_CHANGED` | Response structure changed | Response no longer includes `status` |
+| `ENUM_VALUE_REMOVED` | Enum value was removed | `status` no longer accepts `"pending"` |
+
+### Non-breaking (always safe)
+
+| Change | Why it's safe |
+|---|---|
+| Adding optional fields | Consumers can ignore them |
+| Adding new endpoints | Existing calls aren't affected |
+| Adding optional parameters | Existing calls work without them |
+| Adding enum values | Existing values still work |
+| Relaxing validation | Previously-valid requests remain valid |
+| Improving descriptions | Documentation-only |
+
+## Comparing two schemas
+
+### CLI
+
+```bash
+cvt compare --old ./v1/openapi.json --new ./v2/openapi.json
+cvt compare --old ./v1/openapi.json --new ./v2/openapi.json --json   # for CI
+cvt compare --old ./local.json --new https://api.example.com/openapi.json   # URL also works
+```
+
+Output:
 
 ```text
 ✗ Found 2 breaking change(s):
@@ -66,25 +68,20 @@ cvt compare --old ./v1/openapi.json --new ./v2/openapi.json --json
     New: category (required)
 ```
 
-### Using the SDK
+### SDK
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
-import { ContractValidator } from "@sahina/cvt-sdk";
-
 const validator = new ContractValidator("localhost:9550");
 
-// Register both versions
 await validator.registerSchemaWithVersion("petstore", "./openapi-v1.json", "1.0.0");
 await validator.registerSchemaWithVersion("petstore", "./openapi-v2.json", "2.0.0");
 
-// Compare
 const result = await validator.compareSchemas("petstore", "1.0.0", "2.0.0");
 
 if (!result.compatible) {
-  console.error("Breaking changes detected:");
   for (const change of result.breakingChanges) {
     console.error(`- [${change.type}] ${change.method} ${change.path}`);
     console.error(`  ${change.description}`);
@@ -96,19 +93,13 @@ if (!result.compatible) {
 <TabItem value="python" label="Python">
 
 ```python
-from cvt_sdk import ContractValidator
-
 validator = ContractValidator("localhost:9550")
-
-# Register both versions
 validator.register_schema_with_version("petstore", "./openapi-v1.json", "1.0.0")
 validator.register_schema_with_version("petstore", "./openapi-v2.json", "2.0.0")
 
-# Compare
 result = validator.compare_schemas("petstore", "1.0.0", "2.0.0")
 
 if not result["compatible"]:
-    print("Breaking changes detected:")
     for change in result["breaking_changes"]:
         print(f"- [{change['type']}] {change['method']} {change['path']}")
         print(f"  {change['description']}")
@@ -118,33 +109,18 @@ if not result["compatible"]:
 <TabItem value="go" label="Go">
 
 ```go
-validator, err := cvt.NewValidator("")
-if err != nil {
-    log.Fatal(err)
-}
+validator, _ := cvt.NewValidator("localhost:9550")
 defer validator.Close()
 
-// Register both versions
-err = validator.RegisterSchemaWithVersion(ctx, "petstore", "./openapi-v1.json", "1.0.0")
-if err != nil {
-    log.Fatal(err)
-}
-err = validator.RegisterSchemaWithVersion(ctx, "petstore", "./openapi-v2.json", "2.0.0")
-if err != nil {
-    log.Fatal(err)
-}
+validator.RegisterSchemaWithVersion(ctx, "petstore", "./openapi-v1.json", "1.0.0")
+validator.RegisterSchemaWithVersion(ctx, "petstore", "./openapi-v2.json", "2.0.0")
 
-// Compare
-result, err := validator.CompareSchemas(ctx, "petstore", "1.0.0", "2.0.0")
-if err != nil {
-    log.Fatal(err)
-}
+result, _ := validator.CompareSchemas(ctx, "petstore", "1.0.0", "2.0.0")
 
 if !result.Compatible {
-    fmt.Println("Breaking changes detected:")
     for _, change := range result.BreakingChanges {
-        fmt.Printf("- [%s] %s %s\n", change.Type, change.Method, change.Path)
-        fmt.Printf("  %s\n", change.Description)
+        fmt.Printf("- [%s] %s %s\n  %s\n",
+            change.Type, change.Method, change.Path, change.Description)
     }
 }
 ```
@@ -154,19 +130,15 @@ if !result.Compatible {
 
 ```java
 ContractValidator validator = new ContractValidator("localhost:9550");
-
-// Register both versions
 validator.registerSchemaWithVersion("petstore", "./openapi-v1.json", "1.0.0");
 validator.registerSchemaWithVersion("petstore", "./openapi-v2.json", "2.0.0");
 
-// Compare
 CompareResult result = validator.compareSchemas("petstore", "1.0.0", "2.0.0");
 
 if (!result.isCompatible()) {
-    System.out.println("Breaking changes detected:");
     for (BreakingChange change : result.getBreakingChanges()) {
-        System.out.printf("- [%s] %s %s%n", change.getType(), change.getMethod(), change.getPath());
-        System.out.printf("  %s%n", change.getDescription());
+        System.err.printf("- [%s] %s %s%n  %s%n",
+            change.getType(), change.getMethod(), change.getPath(), change.getDescription());
     }
 }
 ```
@@ -174,436 +146,16 @@ if (!result.isCompatible()) {
 </TabItem>
 </Tabs>
 
----
+## PR check: catch breaking changes before merge
 
-## Deployment Safety (can-i-deploy)
-
-The `can-i-deploy` check combines breaking change detection with the consumer registry to determine if a new schema version is safe to deploy.
-
-### How It Works
-
-```text
-┌─────────────────────┐
-│  New Schema v2.0.0  │
-└─────────────────────┘
-          │
-          ▼
-┌─────────────────────────────────────────────┐
-│            CVT Server                       │
-│                                             │
-│  1. Detect breaking changes from v1.0.0     │
-│  2. Look up registered consumers            │
-│  3. Check which consumers use affected      │
-│     endpoints/fields                        │
-│  4. Return safety assessment                │
-└─────────────────────────────────────────────┘
-          │
-          ▼
-┌─────────────────────┐
-│   Safe / Unsafe     │
-│   + Affected list   │
-└─────────────────────┘
-```
-
-### CLI Usage
-
-```bash
-# Basic usage
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
-
-# With server address
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --server cvt.internal:9550
-
-# JSON output for CI/CD
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --json
-```
-
-### SDK Usage
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-const result = await validator.canIDeploy("petstore", "2.0.0", "prod");
-
-if (result.safeToDeploy) {
-  console.log("Safe to deploy!");
-} else {
-  console.error("UNSAFE:", result.summary);
-
-  // Show breaking changes
-  for (const change of result.breakingChanges) {
-    console.error(`- [${change.type}] ${change.description}`);
-  }
-
-  // Show affected consumers
-  for (const consumer of result.affectedConsumers) {
-    if (consumer.willBreak) {
-      console.error(`Consumer ${consumer.consumerId} will break!`);
-      console.error(
-        `  Uses endpoints: ${consumer.relevantChanges.map((c) => c.path).join(", ")}`,
-      );
-    }
-  }
-}
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-result = validator.can_i_deploy("petstore", "2.0.0", "prod")
-
-if result["safe_to_deploy"]:
-    print("Safe to deploy!")
-else:
-    print(f"UNSAFE: {result['summary']}")
-
-    # Show breaking changes
-    for change in result["breaking_changes"]:
-        print(f"- [{change['type']}] {change['description']}")
-
-    # Show affected consumers
-    for consumer in result["affected_consumers"]:
-        if consumer["will_break"]:
-            print(f"Consumer {consumer['consumer_id']} will break!")
-            paths = ", ".join(c["path"] for c in consumer["relevant_changes"])
-            print(f"  Uses endpoints: {paths}")
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-result, err := validator.CanIDeploy(ctx, "petstore", "2.0.0", "prod")
-if err != nil {
-    log.Fatal(err)
-}
-
-if result.SafeToDeploy {
-    fmt.Println("Safe to deploy!")
-} else {
-    fmt.Println("UNSAFE:", result.Summary)
-
-    // Show breaking changes
-    for _, change := range result.BreakingChanges {
-        fmt.Printf("- [%s] %s\n", change.Type, change.Description)
-    }
-
-    // Show affected consumers
-    for _, consumer := range result.AffectedConsumers {
-        if consumer.WillBreak {
-            fmt.Printf("Consumer %s will break!\n", consumer.ConsumerID)
-            var paths []string
-            for _, c := range consumer.RelevantChanges {
-                paths = append(paths, c.Path)
-            }
-            fmt.Printf("  Uses endpoints: %s\n", strings.Join(paths, ", "))
-        }
-    }
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-CanIDeployResult result = validator.canIDeploy("petstore", "2.0.0", "prod");
-
-if (result.isSafeToDeploy()) {
-    System.out.println("Safe to deploy!");
-} else {
-    System.err.println("UNSAFE: " + result.getSummary());
-
-    // Show breaking changes
-    for (BreakingChange change : result.getBreakingChanges()) {
-        System.err.printf("- [%s] %s%n", change.getType(), change.getDescription());
-    }
-
-    // Show affected consumers
-    for (ConsumerImpact consumer : result.getAffectedConsumers()) {
-        if (consumer.isWillBreak()) {
-            System.err.printf("Consumer %s will break!%n", consumer.getConsumerId());
-            String paths = consumer.getRelevantChanges().stream()
-                .map(BreakingChange::getPath)
-                .collect(Collectors.joining(", "));
-            System.err.printf("  Uses endpoints: %s%n", paths);
-        }
-    }
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Output: Safe to Deploy
-
-```text
-Deployment Safety Check
-=======================
-Schema:      petstore
-Version:     2.0.0
-Environment: prod
-
-✅ SAFE TO DEPLOY
-
-No breaking changes detected that would affect registered consumers.
-```
-
-### Output: Unsafe to Deploy
-
-```text
-Deployment Safety Check
-=======================
-Schema:      petstore
-Version:     2.0.0
-Environment: prod
-
-❌ UNSAFE TO DEPLOY
-
-Breaking changes in v2.0.0:
-  - RESPONSE_SCHEMA_CHANGED: GET /pet/{petId} response removed 'status'
-  - ENDPOINT_REMOVED: DELETE /pet/{petId}
-
-Affected consumers in prod:
-  ├── order-service v2.1.0
-  │   Schema version: 1.0.0
-  │   Impact: BREAKING
-  │   Affected by:
-  │     - GET /pet/{petId}
-  │
-  ├── notification-service v1.5.0
-  │   Schema version: 1.0.0
-  │   Impact: BREAKING
-  │   Affected by:
-  │     - DELETE /pet/{petId}
-  │
-  └── billing-service v1.0.0
-      Schema version: 1.0.0
-      Impact: None
-
-
-Safe consumers:     1/3
-Affected consumers: 2/3
-
-Recommendation: Coordinate with order-service and notification-service teams before deploying.
-```
-
----
-
-## Environment Promotion
-
-CVT tracks consumers per environment, enabling safe promotion workflows.
-
-### Development to Staging to Production
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-const validator = new ContractValidator("cvt.internal:9550");
-
-// 1. Register consumer in dev after tests pass
-await validator.registerConsumer({
-  consumerId: "order-service",
-  consumerVersion: "2.1.0",
-  schemaId: "petstore",
-  schemaVersion: "1.0.0",
-  environment: "dev", // Start in dev
-  usedEndpoints: [
-    { method: "GET", path: "/pet/{petId}", usedFields: ["id", "name"] },
-  ],
-});
-
-// 2. Promote to staging after dev validation
-await validator.registerConsumer({
-  consumerId: "order-service",
-  consumerVersion: "2.1.0",
-  schemaId: "petstore",
-  schemaVersion: "1.0.0",
-  environment: "staging", // Promote to staging
-  usedEndpoints: [
-    { method: "GET", path: "/pet/{petId}", usedFields: ["id", "name"] },
-  ],
-});
-
-// 3. Finally promote to production
-await validator.registerConsumer({
-  consumerId: "order-service",
-  consumerVersion: "2.1.0",
-  schemaId: "petstore",
-  schemaVersion: "1.0.0",
-  environment: "prod", // Production ready
-  usedEndpoints: [
-    { method: "GET", path: "/pet/{petId}", usedFields: ["id", "name"] },
-  ],
-});
-
-validator.close();
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-from cvt_sdk import ContractValidator, RegisterConsumerOptions, EndpointUsage
-
-validator = ContractValidator('cvt.internal:9550')
-
-endpoints = [
-    EndpointUsage(method='GET', path='/pet/{petId}', used_fields=['id', 'name'])
-]
-
-# 1. Register consumer in dev after tests pass
-validator.register_consumer(RegisterConsumerOptions(
-    consumer_id='order-service',
-    consumer_version='2.1.0',
-    schema_id='petstore',
-    schema_version='1.0.0',
-    environment='dev',  # Start in dev
-    used_endpoints=endpoints
-))
-
-# 2. Promote to staging after dev validation
-validator.register_consumer(RegisterConsumerOptions(
-    consumer_id='order-service',
-    consumer_version='2.1.0',
-    schema_id='petstore',
-    schema_version='1.0.0',
-    environment='staging',  # Promote to staging
-    used_endpoints=endpoints
-))
-
-# 3. Finally promote to production
-validator.register_consumer(RegisterConsumerOptions(
-    consumer_id='order-service',
-    consumer_version='2.1.0',
-    schema_id='petstore',
-    schema_version='1.0.0',
-    environment='prod',  # Production ready
-    used_endpoints=endpoints
-))
-
-validator.close()
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-validator, _ := cvt.NewValidator("cvt.internal:9550")
-defer validator.Close()
-
-ctx := context.Background()
-
-endpoints := []cvt.EndpointUsage{
-    {Method: "GET", Path: "/pet/{petId}", UsedFields: []string{"id", "name"}},
-}
-
-// 1. Register consumer in dev after tests pass
-validator.RegisterConsumer(ctx, cvt.RegisterConsumerOptions{
-    ConsumerID:      "order-service",
-    ConsumerVersion: "2.1.0",
-    SchemaID:        "petstore",
-    SchemaVersion:   "1.0.0",
-    Environment:     "dev", // Start in dev
-    UsedEndpoints:   endpoints,
-})
-
-// 2. Promote to staging after dev validation
-validator.RegisterConsumer(ctx, cvt.RegisterConsumerOptions{
-    ConsumerID:      "order-service",
-    ConsumerVersion: "2.1.0",
-    SchemaID:        "petstore",
-    SchemaVersion:   "1.0.0",
-    Environment:     "staging", // Promote to staging
-    UsedEndpoints:   endpoints,
-})
-
-// 3. Finally promote to production
-validator.RegisterConsumer(ctx, cvt.RegisterConsumerOptions{
-    ConsumerID:      "order-service",
-    ConsumerVersion: "2.1.0",
-    SchemaID:        "petstore",
-    SchemaVersion:   "1.0.0",
-    Environment:     "prod", // Production ready
-    UsedEndpoints:   endpoints,
-})
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.RegisterConsumerOptions;
-import io.github.sahina.sdk.EndpointUsage;
-import java.util.List;
-
-ContractValidator validator = new ContractValidator("cvt.internal:9550");
-
-List<EndpointUsage> endpoints = List.of(
-    new EndpointUsage("GET", "/pet/{petId}", List.of("id", "name"))
-);
-
-// 1. Register consumer in dev after tests pass
-validator.registerConsumer(RegisterConsumerOptions.builder()
-    .consumerId("order-service")
-    .consumerVersion("2.1.0")
-    .schemaId("petstore")
-    .schemaVersion("1.0.0")
-    .environment("dev")  // Start in dev
-    .usedEndpoints(endpoints)
-    .build());
-
-// 2. Promote to staging after dev validation
-validator.registerConsumer(RegisterConsumerOptions.builder()
-    .consumerId("order-service")
-    .consumerVersion("2.1.0")
-    .schemaId("petstore")
-    .schemaVersion("1.0.0")
-    .environment("staging")  // Promote to staging
-    .usedEndpoints(endpoints)
-    .build());
-
-// 3. Finally promote to production
-validator.registerConsumer(RegisterConsumerOptions.builder()
-    .consumerId("order-service")
-    .consumerVersion("2.1.0")
-    .schemaId("petstore")
-    .schemaVersion("1.0.0")
-    .environment("prod")  // Production ready
-    .usedEndpoints(endpoints)
-    .build());
-
-validator.close();
-```
-
-</TabItem>
-</Tabs>
-
-### Checking Safety Before Promotion
-
-```bash
-# Before promoting petstore v2.0.0 to production
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
-
-# Output will show if any prod consumers will break
-```
-
----
-
-## CI/CD Integration
-
-### PR Check for Schema Changes
+Wire `cvt compare` into a PR check so breaking changes are flagged at review time, not after merge.
 
 ```yaml
 name: API Compatibility Check
 
 on:
   pull_request:
-    paths:
-      - "api/openapi.json"
+    paths: ['api/openapi.json']
 
 jobs:
   check-breaking-changes:
@@ -617,77 +169,33 @@ jobs:
         run: git show origin/main:api/openapi.json > /tmp/old-schema.json
 
       - name: Check for breaking changes
-        run: |
-          cvt compare --old /tmp/old-schema.json --new ./api/openapi.json
+        run: cvt compare --old /tmp/old-schema.json --new ./api/openapi.json
 ```
 
-### Pre-Deploy Safety Gate
+This catches accidental breakage at the PR. **[CanIDeploy](./can-i-deploy.mdx)** is the complementary gate that runs at deploy time and also checks the registered consumer registry — use both.
 
-```yaml
-deploy:
-  runs-on: ubuntu-latest
-  steps:
-    - name: Check deployment safety
-      run: |
-        result=$(cvt can-i-deploy \
-          --schema ${{ env.SCHEMA_ID }} \
-          --version ${{ github.sha }} \
-          --env prod \
-          --server ${{ secrets.CVT_SERVER }} \
-          --json)
+## Shipping a breaking change on purpose
 
-        if [ $(echo $result | jq '.safe_to_deploy') != "true" ]; then
-          echo "DEPLOYMENT BLOCKED: Breaking changes would affect consumers"
-          echo $result | jq '.affected_consumers[] | select(.will_break) | .consumer_id'
-          exit 1
-        fi
+Sometimes a breaking change is necessary. Four common patterns:
 
-    - name: Deploy
-      if: success()
-      run: ./deploy.sh
-```
+- **Coordinate** — run `can-i-deploy` to find affected consumers, give them a timeline, wait for their updates, then deploy.
+- **Version the API** — keep both versions running (`/api/v1/…` and `/api/v2/…`) during the transition.
+- **Feature flag by header** — same endpoint, different shape by `X-API-Version` header.
+- **Deprecation period** — add `Deprecation` response headers, sunset date, monitor usage, remove later.
 
----
-
-## Handling Breaking Changes
-
-When you need to make a breaking change, you have several options:
-
-### 1. Coordinate with Consumers
-
-1. Run `can-i-deploy` to identify affected consumers
-2. Contact consumer teams with timeline
-3. Wait for consumers to update their code
-4. Deploy once all consumers are ready
-
-### 2. Version Your API
-
-Keep both versions available during transition:
-
-```yaml
-# Old version still available
-/api/v1/pet/{petId}
-
-# New version with breaking changes
-/api/v2/pet/{petId}
-```
-
-### 3. Feature Flags
-
-Gradually roll out changes:
+<details>
+<summary>Feature-flagging a breaking change by header — code example</summary>
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 app.get("/pet/:petId", (req, res) => {
   const pet = getPet(req.params.petId);
 
   if (req.headers["x-api-version"] === "2") {
-    // New format (breaking)
     res.json({ id: pet.id, details: { name: pet.name, category: pet.category } });
   } else {
-    // Old format (compatible)
     res.json({ id: pet.id, name: pet.name, status: pet.status });
   }
 });
@@ -700,13 +208,9 @@ app.get("/pet/:petId", (req, res) => {
 @app.get("/pet/{pet_id}")
 def get_pet(pet_id: str, request: Request):
     pet = get_pet_by_id(pet_id)
-
     if request.headers.get("x-api-version") == "2":
-        # New format (breaking)
         return {"id": pet.id, "details": {"name": pet.name, "category": pet.category}}
-    else:
-        # Old format (compatible)
-        return {"id": pet.id, "name": pet.name, "status": pet.status}
+    return {"id": pet.id, "name": pet.name, "status": pet.status}
 ```
 
 </TabItem>
@@ -715,19 +219,16 @@ def get_pet(pet_id: str, request: Request):
 ```go
 func getPetHandler(w http.ResponseWriter, r *http.Request) {
     pet := getPet(chi.URLParam(r, "petId"))
-
     if r.Header.Get("X-API-Version") == "2" {
-        // New format (breaking)
         json.NewEncoder(w).Encode(map[string]any{
             "id": pet.ID,
             "details": map[string]any{"name": pet.Name, "category": pet.Category},
         })
-    } else {
-        // Old format (compatible)
-        json.NewEncoder(w).Encode(map[string]any{
-            "id": pet.ID, "name": pet.Name, "status": pet.Status,
-        })
+        return
     }
+    json.NewEncoder(w).Encode(map[string]any{
+        "id": pet.ID, "name": pet.Name, "status": pet.Status,
+    })
 }
 ```
 
@@ -741,57 +242,27 @@ public ResponseEntity<Map<String, Object>> getPet(
     @RequestHeader(value = "X-API-Version", required = false) String apiVersion
 ) {
     Pet pet = petService.getPet(petId);
-
     if ("2".equals(apiVersion)) {
-        // New format (breaking)
         return ResponseEntity.ok(Map.of(
             "id", pet.getId(),
             "details", Map.of("name", pet.getName(), "category", pet.getCategory())
         ));
-    } else {
-        // Old format (compatible)
-        return ResponseEntity.ok(Map.of(
-            "id", pet.getId(), "name", pet.getName(), "status", pet.getStatus()
-        ));
     }
+    return ResponseEntity.ok(Map.of(
+        "id", pet.getId(), "name", pet.getName(), "status", pet.getStatus()
+    ));
 }
 ```
 
 </TabItem>
 </Tabs>
 
-### 4. Deprecation Period
+</details>
 
-1. Add deprecation headers to old endpoints
-2. Set a sunset date
-3. Monitor usage metrics
-4. Remove after deprecation period
+## Related
 
----
-
-## Best Practices
-
-### For API Producers
-
-1. **Run comparisons in CI** - Catch breaking changes before they're merged
-2. **Use can-i-deploy before production** - Make it a required gate
-3. **Version your API** - Major versions for breaking changes
-4. **Communicate deprecations** - Give consumers time to adapt
-
-### For API Consumers
-
-1. **Register your dependencies** - Enable can-i-deploy checks
-2. **Specify used fields** - Help producers understand impact
-3. **Test against schema** - Catch issues before producers deploy
-4. **Monitor deprecation warnings** - Plan updates proactively
-
----
-
-## Related Documentation
-
-- **[Consumer Testing Guide](./consumer-testing.mdx)** - Register as a consumer
-- **[Producer Testing Guide](./producer-testing.mdx)** - Validate your API
-- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** - Pipeline examples
-- **[Configuration Reference](../reference/configuration.mdx)** - Environment variables and settings
-- **[CLI Reference](../reference/cli.mdx)** - Command-line options
-- **[API Reference](../reference/api.mdx)** - Message types
+- **[CanIDeploy](./can-i-deploy.mdx)** — the deploy-time safety gate that uses breaking-change detection against the consumer registry.
+- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** — full pipeline examples.
+- **[Producer Testing Guide](./producer-testing.mdx)** — validate your handlers match your spec.
+- **[Consumer Testing Guide](./consumer-testing.mdx)** — register as a consumer so `can-i-deploy` can see you.
+- **[CLI Reference](../reference/cli.mdx#compare)** — full flag reference for `cvt compare`.

--- a/docs/guides/can-i-deploy.mdx
+++ b/docs/guides/can-i-deploy.mdx
@@ -1,0 +1,304 @@
+---
+title: CanIDeploy
+sidebar_label: CanIDeploy
+sidebar_position: 3
+description: Block breaking deploys before they ship — CVT's safety gate between producers and consumers
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# CanIDeploy: the safety gate between producers and consumers
+
+`can-i-deploy` is the payoff of everything else CVT does. The producer writes an OpenAPI spec; consumers register which endpoints and fields they depend on; before the producer ships a schema change, `can-i-deploy` checks whether any real consumer would break. If the answer is yes, the deploy is blocked.
+
+This page walks through using it. For Alice and Bob's story and *why* you'd want this gate, see the [Introduction](../intro.md).
+
+## TL;DR
+
+```bash
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
+```
+
+```text
+✅ SAFE TO DEPLOY
+No breaking changes detected that would affect registered consumers.
+```
+
+Exit code `0` → deploy. Exit code `1` → don't deploy; fix the breakage or coordinate with the affected consumer team first.
+
+## How it works
+
+```text
+     New schema v2.0.0 about to deploy
+                  │
+                  ▼
+       ┌──────────────────────────┐
+       │       CVT Server         │
+       │                          │
+       │ 1. Diff v2.0.0 vs v1.0.0 │   ← breaking-change detection
+       │ 2. Look up registered    │
+       │    consumers in `prod`   │   ← consumer registry
+       │ 3. Check which consumers │
+       │    touch affected        │
+       │    endpoints/fields      │
+       │ 4. Return verdict        │
+       └──────────────────────────┘
+                  │
+                  ▼
+       ┌──────────────────────────┐
+       │  SAFE / UNSAFE + details │
+       └──────────────────────────┘
+```
+
+The check combines two things CVT already knows:
+- **Breaking changes**: diff the new schema against the old one (see [Breaking Changes Guide](./breaking-changes.mdx)).
+- **Consumer registry**: which services registered as consumers in this environment, and which endpoints and fields they said they use (see [Consumer Testing Guide](./consumer-testing.mdx#consumer-registration)).
+
+A breaking change matters only if a registered consumer depends on the changed piece. That intersection is the verdict.
+
+## Step 1 — make sure consumers are registered
+
+`can-i-deploy` can only protect consumers that are registered with CVT in the target environment. Each consumer service registers after its contract tests pass:
+
+```typescript
+await validator.registerConsumer({
+  consumerId: "checkout-service",
+  consumerVersion: "1.0.0",
+  schemaId: "petstore",
+  schemaVersion: "1.0.0",
+  environment: "prod",
+  usedEndpoints: [
+    { method: "GET", path: "/pet/{petId}", usedFields: ["id", "name", "status"] },
+  ],
+});
+```
+
+Full walkthrough: [Consumer Testing → Consumer Registration](./consumer-testing.mdx#consumer-registration).
+
+:::info No consumers registered yet?
+`can-i-deploy` returns *safe* when no consumers are registered for the schema in that environment — there's nothing to break. This is expected on day one; it becomes load-bearing once consumers start registering. See the [no-consumers troubleshooting](#no-consumers-registered) note below.
+:::
+
+## Step 2 — run the check in CI
+
+Put the check in your producer's deploy pipeline, before the deploy step.
+
+### GitHub Actions
+
+```yaml
+- name: Check deployment safety
+  run: |
+    cvt can-i-deploy \
+      --schema petstore \
+      --version ${{ github.sha }} \
+      --env prod \
+      --server ${{ secrets.CVT_SERVER }}
+
+- name: Deploy
+  if: success()
+  run: ./deploy.sh
+```
+
+The CLI exits `1` on unsafe; failing the safety step stops the deploy. For GitLab and Jenkins examples, see the [CI/CD Integration Guide](./ci-cd-integration.mdx).
+
+### JSON output for custom pipelines
+
+```bash
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod --json > check.json
+
+if [ "$(jq '.safe_to_deploy' check.json)" != "true" ]; then
+  echo "Deploy blocked:"
+  jq '.affected_consumers[] | select(.will_break) | .consumer_id' check.json
+  exit 1
+fi
+```
+
+Full flag reference (including `--timeout`, `--server`, exit codes): [CLI Reference → can-i-deploy](../reference/cli.mdx#can-i-deploy).
+
+## Step 3 — interpret the verdict
+
+| Verdict | What it means | What to do |
+|---|---|---|
+| **✅ SAFE TO DEPLOY** | No breaking changes, or breaking changes don't touch any registered consumer's endpoints/fields | Deploy |
+| **❌ UNSAFE TO DEPLOY** | At least one registered consumer depends on something this change breaks | See breakage + affected-consumers list; fix the change or coordinate with the consumer team |
+| **⚠️ NO CONSUMERS** | No services are registered as consumers for this schema in this environment | Safe on technicality; confirm with your platform/consumer teams that they're actually registering |
+
+### Example: unsafe output
+
+```text
+Deployment Safety Check
+=======================
+Schema:      petstore
+Version:     2.0.0
+Environment: prod
+
+❌ UNSAFE TO DEPLOY
+
+Breaking changes in v2.0.0:
+  - RESPONSE_SCHEMA_CHANGED: GET /pet/{petId} response removed 'status'
+  - ENDPOINT_REMOVED: DELETE /pet/{petId}
+
+Affected consumers in prod:
+  ├── order-service v2.1.0
+  │   Schema version: 1.0.0
+  │   Impact: BREAKING
+  │   Affected by:
+  │     - GET /pet/{petId}
+  │
+  ├── notification-service v1.5.0
+  │   Schema version: 1.0.0
+  │   Impact: BREAKING
+  │   Affected by:
+  │     - DELETE /pet/{petId}
+  │
+  └── billing-service v1.0.0
+      Schema version: 1.0.0
+      Impact: None
+
+Safe consumers:     1/3
+Affected consumers: 2/3
+
+Recommendation: Coordinate with order-service and notification-service teams before deploying.
+```
+
+The verdict names the affected services and the specific endpoints they depend on — enough to start the conversation.
+
+## Next
+
+- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** — full pipeline examples for GitHub Actions, GitLab, Jenkins.
+- **[Breaking Changes Guide](./breaking-changes.mdx)** — what counts as breaking, how to make changes without breaking consumers.
+- **[Consumer Testing Guide](./consumer-testing.mdx#consumer-registration)** — how consumers declare their dependencies so `can-i-deploy` can see them.
+
+<details>
+<summary>SDK usage (instead of the CLI)</summary>
+
+<Tabs groupId="sdk-language">
+<TabItem value="nodejs" label="Node.js" default>
+
+```typescript
+const result = await validator.canIDeploy("petstore", "2.0.0", "prod");
+
+if (result.safeToDeploy) {
+  console.log("Safe to deploy!");
+} else {
+  console.error("UNSAFE:", result.summary);
+  for (const change of result.breakingChanges) {
+    console.error(`- [${change.type}] ${change.description}`);
+  }
+  for (const consumer of result.affectedConsumers) {
+    if (consumer.willBreak) {
+      console.error(`Consumer ${consumer.consumerId} will break!`);
+    }
+  }
+  process.exit(1);
+}
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+result = validator.can_i_deploy("petstore", "2.0.0", "prod")
+
+if result["safe_to_deploy"]:
+    print("Safe to deploy!")
+else:
+    print(f"UNSAFE: {result['summary']}")
+    for change in result["breaking_changes"]:
+        print(f"- [{change['type']}] {change['description']}")
+    for consumer in result["affected_consumers"]:
+        if consumer["will_break"]:
+            print(f"Consumer {consumer['consumer_id']} will break!")
+    sys.exit(1)
+```
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+```go
+result, err := validator.CanIDeploy(ctx, "petstore", "2.0.0", "prod")
+if err != nil {
+    log.Fatal(err)
+}
+
+if result.SafeToDeploy {
+    fmt.Println("Safe to deploy!")
+} else {
+    fmt.Println("UNSAFE:", result.Summary)
+    for _, change := range result.BreakingChanges {
+        fmt.Printf("- [%s] %s\n", change.Type, change.Description)
+    }
+    for _, consumer := range result.AffectedConsumers {
+        if consumer.WillBreak {
+            fmt.Printf("Consumer %s will break!\n", consumer.ConsumerID)
+        }
+    }
+    os.Exit(1)
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+CanIDeployResult result = validator.canIDeploy("petstore", "2.0.0", "prod");
+
+if (result.isSafeToDeploy()) {
+    System.out.println("Safe to deploy!");
+} else {
+    System.err.println("UNSAFE: " + result.getSummary());
+    for (BreakingChange change : result.getBreakingChanges()) {
+        System.err.printf("- [%s] %s%n", change.getType(), change.getDescription());
+    }
+    for (ConsumerImpact consumer : result.getAffectedConsumers()) {
+        if (consumer.isWillBreak()) {
+            System.err.printf("Consumer %s will break!%n", consumer.getConsumerId());
+        }
+    }
+    System.exit(1);
+}
+```
+
+</TabItem>
+</Tabs>
+
+</details>
+
+<details>
+<summary>Environment promotion (dev → staging → prod)</summary>
+
+`can-i-deploy` is environment-scoped. A consumer registered in `dev` doesn't protect `prod`. Run the check per target environment before promoting:
+
+```bash
+# About to promote petstore v2.0.0 from staging to prod
+cvt can-i-deploy --schema petstore --version 2.0.0 --env staging  # first
+cvt can-i-deploy --schema petstore --version 2.0.0 --env prod     # then
+```
+
+Consumers typically register in each environment as they promote there — on dev deploy, on staging deploy, and on prod deploy. See [Consumer Testing → Consumer Registration](./consumer-testing.mdx#consumer-registration).
+
+</details>
+
+<details id="no-consumers-registered">
+<summary>Troubleshooting: "No consumers registered"</summary>
+
+If `can-i-deploy` returns *safe* with `NO CONSUMERS` in the summary, CVT has no record of any service registered against this schema in this environment. This can mean:
+
+- **You're the first to deploy and no one consumes you yet** — expected, not a problem.
+- **Consumers exist but aren't registering in CI** — the gate is a false-negative until they register. Confirm with their teams that they run `registerConsumer` in their pipelines.
+- **Wrong environment** — your CI passed `--env prod` but consumers registered in `staging`. Double-check the `--env` flag.
+- **Wrong schema ID** — typos in `--schema` silently pass because there are no registrations for `petsotre` (say).
+
+Fix by making consumer registration part of each consumer service's CI — on green main, register against each environment the service deploys to.
+
+</details>
+
+<details>
+<summary>What counts as "breaking"?</summary>
+
+Any change that would make an existing consumer fail: removed endpoints, newly-required fields, renamed response fields, type changes, removed enum values. Full list with examples: [Breaking Changes Guide](./breaking-changes.mdx#what-are-breaking-changes).
+
+Non-breaking (safe to add at any time): optional fields, new endpoints, new enum values, relaxed validation.
+
+</details>

--- a/docs/guides/ci-cd-integration.mdx
+++ b/docs/guides/ci-cd-integration.mdx
@@ -17,8 +17,8 @@ A typical CVT-enabled pipeline includes:
 2. **Consumer registration** - Register your service's API dependencies after tests pass
 3. **Deployment safety checks** - Run `can-i-deploy` before deploying schema changes
 
-:::tip Schema-Specific PR Checks
-For PR checks that detect breaking changes when your OpenAPI spec file changes, see the [Breaking Changes CI/CD section](./breaking-changes.mdx#cicd-integration).
+:::tip PR check for breaking changes
+For a PR-time check that flags breaking changes the moment a spec change is opened, see the [Breaking Changes Guide → PR check](./breaking-changes.mdx#pr-check-catch-breaking-changes-before-merge). It's complementary to `can-i-deploy`: PR check catches accidental breakage early; `can-i-deploy` blocks the deploy when a real consumer would be hit.
 :::
 
 ---
@@ -355,5 +355,6 @@ pipeline {
 
 - **[Consumer Testing Guide](./consumer-testing.mdx)** - Test your API integrations
 - **[Producer Testing Guide](./producer-testing.mdx)** - Validate your own APIs
-- **[Breaking Changes Guide](./breaking-changes.mdx)** - Schema compatibility and can-i-deploy
+- **[CanIDeploy](./can-i-deploy.mdx)** - The deploy-time safety gate used in every pipeline example above
+- **[Breaking Changes Guide](./breaking-changes.mdx)** - What counts as breaking, plus a PR-time check
 - **[Configuration Reference](../reference/configuration.mdx)** - Environment variables and settings

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -2,7 +2,7 @@
 title: Consumer Testing Guide
 sidebar_label: Consumer Testing
 sidebar_position: 1
-description: Complete guide to testing your API consumers with CVT
+description: Validate your service's HTTP calls against upstream OpenAPI contracts
 ---
 
 import Tabs from "@theme/Tabs";
@@ -10,235 +10,28 @@ import TabItem from "@theme/TabItem";
 
 # Consumer Testing Guide
 
-This guide covers how to test your service's API integrations using CVT. Consumer testing validates that your HTTP calls to upstream APIs match their published OpenAPI contracts.
+Consumer testing answers: **"Am I calling this API correctly, and will I notice when it changes?"** If you're new to CVT, read the [Introduction](../intro.md) first — the Alice/Bob story explains why this matters. For a one-test walkthrough, see [Quick Start](../getting-started/quick-start.mdx).
 
-:::tip Example Schema
-The examples in this guide use the Petstore schema from `sdks/shared/openapi.json`. Copy it to your project as `openapi.json` or adjust the paths to reference it directly.
+This guide covers the three validation approaches and consumer registration (the thing that lets producers run [`can-i-deploy`](./can-i-deploy.mdx) against you).
 
-All `registerSchema` methods accept both **file paths** and **URLs**:
+## Approaches at a glance
 
-```typescript
-// From file
-await validator.registerSchema("petstore", "./openapi.json");
-// From URL
-await validator.registerSchema(
-  "petstore",
-  "https://petstore3.swagger.io/api/v3/openapi.json",
-);
-```
+| Approach | How it works | Needs real API? | Best for |
+|---|---|---|---|
+| **Direct `validate()`** | Call `validator.validate(request, response)` per interaction | Yes | Learning; specific edge cases |
+| **HTTP adapter** | Wrap your HTTP client; every call is validated automatically | Yes | Retrofitting existing integration tests |
+| **Mock adapter** | CVT generates spec-compliant responses in-process; no real call | No | CI without upstream services; unit tests |
 
-:::
-
-## Overview
-
-Consumer testing answers the question: **"Am I calling this API correctly?"**
-
-When your service depends on external APIs, you need confidence that:
-
-- Your requests are properly formatted
-- You handle responses correctly
-- You won't break when upstream APIs change
-
-```text
-┌─────────────────────┐     HTTP      ┌─────────────────────┐
-│   Your Service      │ ────────────► │   Upstream API      │
-│   (Consumer)        │               │   (Producer)        │
-└─────────────────────┘               └─────────────────────┘
-         │                                      │
-         │ Validate & Register Consumer         │ Register Schema (owns it)
-         ▼                                      ▼
-┌───────────────────────────────────────────────────────────┐
-│                    CVT Server (shared)                    │
-│              Producer's Schema = Source of Truth          │
-└───────────────────────────────────────────────────────────┘
-```
-
-:::info Who registers the schema?
-In production workflows, **the producer registers their OpenAPI schema** with the shared CVT server — they own the spec and publish it as part of their CI/CD pipeline. Consumers validate their interactions against that registered schema and register themselves as consumers.
-
-The `registerSchema` calls in the examples below are a **convenience for local development and getting started**. In a team environment, the producer's pipeline handles schema registration (see the [CI/CD Integration Guide](./ci-cd-integration.mdx#recommended-workflow)).
-:::
+All three require the producer's schema to be registered with CVT. In production workflows the producer's CI does that; for local dev you can register it yourself with `validator.registerSchema(...)`.
 
 ---
 
-## Quick Start
+## Approach 1 — Direct `validate()`
 
-### 1. Start the CVT Server
-
-```bash
-# Using the published Docker image (recommended)
-docker run -d -p 9550:9550 -p 9551:9551 ghcr.io/sahina/cvt:latest
-
-# Or using Docker Compose (if you've cloned the repository)
-make up
-
-# Or build and run locally
-make run-server
-```
-
-### 2. Write Your First Contract Test
+Explicit per-interaction validation. Full control over request/response shapes, ideal for testing specific cases.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-import { ContractValidator } from "@sahina/cvt-sdk";
-
-describe("Petstore Contract", () => {
-  let validator: ContractValidator;
-
-  beforeAll(async () => {
-    validator = new ContractValidator("localhost:9550");
-    await validator.registerSchema("petstore", "./openapi.json");
-  });
-
-  afterAll(() => validator.close());
-
-  it("GET /pet/{petId} returns valid response", async () => {
-    const result = await validator.validate(
-      { method: "GET", path: "/pet/123" },
-      {
-        statusCode: 200,
-        body: { id: 123, name: "Fluffy", status: "available", photoUrls: [] },
-      },
-    );
-    expect(result.valid).toBe(true);
-  });
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-import pytest
-from cvt_sdk import ContractValidator
-
-@pytest.fixture
-def validator():
-    v = ContractValidator('localhost:9550')
-    v.register_schema('petstore', './openapi.json')
-    yield v
-    v.close()
-
-def test_get_pet_returns_valid_response(validator):
-    result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/123'},
-        response={'status_code': 200, 'body': {'id': 123, 'name': 'Fluffy', 'status': 'available', 'photoUrls': []}}
-    )
-    assert result['valid'] is True
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-package main
-
-import (
-    "context"
-    "testing"
-
-    "github.com/sahina/cvt/sdks/go/cvt"
-    "github.com/stretchr/testify/assert"
-)
-
-func TestGetPetReturnsValidResponse(t *testing.T) {
-    ctx := context.Background()
-    validator, err := cvt.NewValidator("localhost:9550")
-    assert.NoError(t, err)
-    defer validator.Close()
-
-    err = validator.RegisterSchema(ctx, "petstore", "./openapi.json")
-    assert.NoError(t, err)
-
-    result, err := validator.Validate(ctx, cvt.ValidationRequest{
-        Method: "GET",
-        Path:   "/pet/123",
-    }, cvt.ValidationResponse{
-        StatusCode: 200,
-        Body:       map[string]any{"id": 123, "name": "Fluffy", "status": "available", "photoUrls": []any{}},
-    })
-    assert.NoError(t, err)
-    assert.True(t, result.Valid)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.ValidationRequest;
-import io.github.sahina.sdk.ValidationResponse;
-import io.github.sahina.sdk.ValidationResult;
-import org.junit.jupiter.api.*;
-
-class PetstoreContractTest {
-    private static ContractValidator validator;
-
-    @BeforeAll
-    static void setup() throws Exception {
-        validator = new ContractValidator("localhost:9550");
-        validator.registerSchema("petstore", "./openapi.json");
-    }
-
-    @AfterAll
-    static void cleanup() {
-        validator.close();
-    }
-
-    @Test
-    void getPetReturnsValidResponse() {
-        ValidationResult result = validator.validate(
-            ValidationRequest.builder().method("GET").path("/pet/123").build(),
-            ValidationResponse.builder()
-                .statusCode(200)
-                .body("{\"id\": 123, \"name\": \"Fluffy\", \"status\": \"available\", \"photoUrls\": []}")
-                .build()
-        );
-        Assertions.assertTrue(result.isValid());
-    }
-}
-```
-
-</TabItem>
-</Tabs>
-
----
-
-## Validation Approaches
-
-CVT supports multiple ways to validate your API interactions.
-
-### Approach Comparison
-
-| Approach         | Control | Needs Producer | Best For           |
-| ---------------- | ------- | -------------- | ------------------ |
-| **Manual**       | Full    | Yes            | Edge cases, errors |
-| **HTTP Adapter** | Medium  | Yes            | Existing tests     |
-| **Mock Client**  | Low     | No             | CI/CD, unit tests  |
-
-- **Manual**: Call `validate()` explicitly. Full control for edge cases and error scenarios.
-- **HTTP Adapter**: Wraps your HTTP client. Automatic validation. Drop-in for existing tests.
-- **Mock Client**: No real HTTP calls. CVT generates responses from schema. Fast and deterministic.
-
-### Choosing an Approach
-
-| Scenario                            | Recommended Approach |
-| ----------------------------------- | -------------------- |
-| CI/CD pipeline without services     | Mock Client          |
-| Adding validation to existing tests | HTTP Adapter         |
-| Testing specific error responses    | Manual Validation    |
-| Unit testing consumer logic         | Mock Client          |
-| Integration testing with real API   | HTTP Adapter         |
-
-### Approach 1: Manual Validation
-
-Build request/response objects and validate them directly:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 import { ContractValidator } from "@sahina/cvt-sdk";
@@ -246,7 +39,6 @@ import { ContractValidator } from "@sahina/cvt-sdk";
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
 
-// Validate a specific interaction
 const result = await validator.validate(
   {
     method: "GET",
@@ -273,25 +65,20 @@ validator.close();
 ```python
 from cvt_sdk import ContractValidator
 
-validator = ContractValidator('localhost:9550')
-validator.register_schema('petstore', './openapi.json')
+validator = ContractValidator("localhost:9550")
+validator.register_schema("petstore", "./openapi.json")
 
-# Validate a specific interaction
 result = validator.validate(
-    request={
-        'method': 'GET',
-        'path': '/pet/123',
-        'headers': {'Accept': 'application/json'}
-    },
-    response={
-        'status_code': 200,
-        'headers': {'Content-Type': 'application/json'},
-        'body': {'id': 123, 'name': 'Fluffy', 'status': 'available', 'photoUrls': []}
-    }
+    request={"method": "GET", "path": "/pet/123",
+             "headers": {"Accept": "application/json"}},
+    response={"status_code": 200,
+              "headers": {"Content-Type": "application/json"},
+              "body": {"id": 123, "name": "Fluffy",
+                       "status": "available", "photoUrls": []}},
 )
 
-if not result['valid']:
-    print('Validation errors:', result['errors'])
+if not result["valid"]:
+    print("Validation errors:", result["errors"])
 
 validator.close()
 ```
@@ -306,7 +93,6 @@ defer validator.Close()
 ctx := context.Background()
 validator.RegisterSchema(ctx, "petstore", "./openapi.json")
 
-// Validate a specific interaction
 result, _ := validator.Validate(ctx, cvt.ValidationRequest{
     Method:  "GET",
     Path:    "/pet/123",
@@ -314,7 +100,10 @@ result, _ := validator.Validate(ctx, cvt.ValidationRequest{
 }, cvt.ValidationResponse{
     StatusCode: 200,
     Headers:    map[string]string{"Content-Type": "application/json"},
-    Body:       map[string]any{"id": 123, "name": "Fluffy", "status": "available", "photoUrls": []any{}},
+    Body: map[string]any{
+        "id": 123, "name": "Fluffy", "status": "available",
+        "photoUrls": []any{},
+    },
 })
 
 if !result.Valid {
@@ -326,25 +115,18 @@ if !result.Valid {
 <TabItem value="java" label="Java">
 
 ```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.ValidationRequest;
-import io.github.sahina.sdk.ValidationResponse;
-import io.github.sahina.sdk.ValidationResult;
-
 ContractValidator validator = new ContractValidator("localhost:9550");
 validator.registerSchema("petstore", "./openapi.json");
 
-// Validate a specific interaction
 ValidationResult result = validator.validate(
     ValidationRequest.builder()
-        .method("GET")
-        .path("/pet/123")
+        .method("GET").path("/pet/123")
         .header("Accept", "application/json")
         .build(),
     ValidationResponse.builder()
         .statusCode(200)
         .header("Content-Type", "application/json")
-        .body("{\"id\": 123, \"name\": \"Fluffy\", \"status\": \"available\", \"photoUrls\": []}")
+        .body("{\"id\":123,\"name\":\"Fluffy\",\"status\":\"available\",\"photoUrls\":[]}")
         .build()
 );
 
@@ -358,12 +140,14 @@ validator.close();
 </TabItem>
 </Tabs>
 
-### Approach 2: HTTP Adapter (Recommended)
+---
 
-Wrap your HTTP client for automatic validation of all requests/responses:
+## Approach 2 — HTTP adapter (recommended for existing tests)
+
+Wrap your HTTP client. Every request/response flowing through it is validated automatically — no per-call changes to existing tests.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 import axios from "axios";
@@ -375,7 +159,6 @@ await validator.registerSchema("petstore", "./openapi.json");
 
 const api = axios.create({ baseURL: "http://petstore-api" });
 
-// Wrap axios - all traffic is now validated automatically
 createAxiosAdapter({
   axios: api,
   validator,
@@ -385,8 +168,7 @@ createAxiosAdapter({
   },
 });
 
-// Use normally - validation happens transparently
-const pet = await api.get("/pet/123");
+const pet = await api.get("/pet/123"); // validated transparently
 
 validator.close();
 ```
@@ -398,17 +180,11 @@ validator.close();
 from cvt_sdk import ContractValidator
 from cvt_sdk.adapters import create_validating_session
 
-validator = ContractValidator('localhost:9550')
-validator.register_schema('petstore', './openapi.json')
+validator = ContractValidator("localhost:9550")
+validator.register_schema("petstore", "./openapi.json")
 
-# Create validating session - all traffic is validated automatically
-session = create_validating_session(
-    validator=validator,
-    auto_validate=True,
-)
-
-# Use normally - validation happens transparently
-response = session.get('http://petstore-api/pet/123')
+session = create_validating_session(validator=validator, auto_validate=True)
+response = session.get("http://petstore-api/pet/123")  # validated transparently
 
 validator.close()
 ```
@@ -423,51 +199,36 @@ defer validator.Close()
 ctx := context.Background()
 validator.RegisterSchema(ctx, "petstore", "./openapi.json")
 
-// Wrap http.Client with validating round tripper
 rt := adapters.NewValidatingRoundTripper(adapters.RoundTripperConfig{
     Validator:    validator,
     AutoValidate: true,
-    OnValidationFailure: func(result *cvt.ValidationResult, req *http.Request, resp *http.Response) error {
-        return fmt.Errorf("contract violation: %v", result.Errors)
+    OnValidationFailure: func(r *cvt.ValidationResult, req *http.Request, resp *http.Response) error {
+        return fmt.Errorf("contract violation: %v", r.Errors)
     },
 })
 
 client := &http.Client{Transport: rt}
-
-// Use normally - validation happens transparently
-resp, _ := client.Get("http://petstore-api/pet/123")
+resp, _ := client.Get("http://petstore-api/pet/123") // validated transparently
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.adapters.OkHttpContractAdapter;
-import io.github.sahina.sdk.adapters.AdapterConfig;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
 ContractValidator validator = ContractValidator.builder()
-    .address("localhost:9550")
-    .build();
+    .address("localhost:9550").build();
 validator.registerSchema("petstore", "./openapi.json");
 
-// Create OkHttp interceptor that validates against schema
 OkHttpContractAdapter adapter = new OkHttpContractAdapter(validator)
-    .withConfig(AdapterConfig.builder()
-        .autoValidate(true)
-        .build());
+    .withConfig(AdapterConfig.builder().autoValidate(true).build());
 
 OkHttpClient client = new OkHttpClient.Builder()
     .addInterceptor(adapter)
     .build();
 
-// Use normally - validation happens transparently
 Response response = client.newCall(
     new Request.Builder().url("http://petstore-api/pet/123").build()
-).execute();
+).execute(); // validated transparently
 
 validator.close();
 ```
@@ -475,21 +236,14 @@ validator.close();
 </TabItem>
 </Tabs>
 
-### Approach 3: Mock Client
+---
 
-Use the mock adapter for tests without a real API:
+## Approach 3 — Mock adapter (no real API needed)
 
-:::tip Standalone Mock Server
-Need a running HTTP server instead of an in-process mock? Use [`cvt mock`](../reference/cli.mdx#mock) to start a standalone mock server from any OpenAPI schema — great for frontend development, manual testing, or non-SDK languages:
-
-```bash
-cvt mock --schema ./openapi.json --validate-requests --watch
-```
-
-:::
+CVT generates spec-compliant responses directly from the schema. Great for CI that has no upstream dependency, unit tests, frontend dev.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 import { ContractValidator } from "@sahina/cvt-sdk";
@@ -498,14 +252,12 @@ import { createMockAdapter } from "@sahina/cvt-sdk/adapters";
 const validator = new ContractValidator("localhost:9550");
 await validator.registerSchema("petstore", "./openapi.json");
 
-// Create mock adapter that auto-generates responses from schema
 const mock = createMockAdapter({ validator, cache: true });
 
-// Make requests - responses are generated from OpenAPI schema
 const response = await mock.fetch("http://mock.petstore/pet/456");
 const pet = await response.json();
 
-// Check recorded interactions for consumer registration
+// Captured interactions useful for auto-registering as a consumer (see below)
 const interactions = mock.getInteractions();
 
 validator.close();
@@ -518,19 +270,14 @@ validator.close();
 from cvt_sdk import ContractValidator
 from cvt_sdk.adapters import create_mock_session
 
-validator = ContractValidator('localhost:9550')
-validator.register_schema('petstore', './openapi.json')
+validator = ContractValidator("localhost:9550")
+validator.register_schema("petstore", "./openapi.json")
 
-# Create mock session that auto-generates responses from schema
 mock = create_mock_session(validator=validator, cache=True)
-
-# Make requests - responses are generated from OpenAPI schema
-response = mock.get('http://mock.petstore/pet/456')
+response = mock.get("http://mock.petstore/pet/456")
 pet = response.json()
 
-# Check recorded interactions for consumer registration
 interactions = mock.get_interactions()
-
 validator.close()
 ```
 
@@ -544,15 +291,12 @@ defer validator.Close()
 ctx := context.Background()
 validator.RegisterSchema(ctx, "petstore", "./openapi.json")
 
-// Create mock client that auto-generates responses from schema
 mock := adapters.NewMock(validator, adapters.WithCache())
 mockClient := mock.Client()
 
-// Make requests - responses are generated from OpenAPI schema
 req, _ := http.NewRequest("GET", "http://mock.petstore/pet/456", nil)
 resp, _ := mockClient.Do(req)
 
-// Check recorded interactions for consumer registration
 interactions := mock.GetInteractions()
 ```
 
@@ -560,249 +304,40 @@ interactions := mock.GetInteractions()
 <TabItem value="java" label="Java">
 
 ```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.adapters.MockInterceptor;
-import io.github.sahina.sdk.adapters.MockConfig;
-import io.github.sahina.sdk.adapters.CapturedInteraction;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
 ContractValidator validator = ContractValidator.builder()
-    .address("localhost:9550")
-    .build();
+    .address("localhost:9550").build();
 validator.registerSchema("petstore", "./openapi.json");
 
-// Create mock interceptor that auto-generates responses from schema
 MockInterceptor mock = new MockInterceptor(validator)
-    .withConfig(MockConfig.builder()
-        .cache()
-        .build());
+    .withConfig(MockConfig.builder().cache().build());
 
 OkHttpClient client = new OkHttpClient.Builder()
     .addInterceptor(mock)
     .build();
 
-// Make requests - responses are generated from OpenAPI schema
 Response response = client.newCall(
     new Request.Builder().url("http://mock.petstore/pet/456").build()
 ).execute();
 
-// Check recorded interactions for consumer registration
 List<CapturedInteraction> interactions = mock.getInteractions();
-
 validator.close();
 ```
 
 </TabItem>
 </Tabs>
 
-Benefits:
-
-- No real API endpoint needed
-- Responses match schema exactly
-- Interactions captured for auto-registration
+:::tip Standalone mock server
+Need a real HTTP mock server (for frontend dev, manual testing, or non-SDK languages)? Use [`cvt mock`](../reference/cli.mdx#mock) to boot one from any OpenAPI schema: `cvt mock --schema ./openapi.json --validate-requests --watch`.
+:::
 
 ---
 
-## Consumer Registration
+## Consumer registration
 
-Register your service as a consumer to enable deployment safety checks.
-
-### Prerequisites
-
-Before creating adapters or registering consumers, ensure the schema is registered:
-
-```typescript
-const validator = new ContractValidator("localhost:9550");
-
-// Always register schema first
-await validator.registerSchema("petstore", "./openapi.json");
-
-// Now you can create adapters or validate interactions
-```
-
-### Auto-Registration (Recommended)
-
-Register from captured test interactions - endpoints and fields are extracted automatically:
+After your contract tests pass, register your service as a consumer so the producer's `can-i-deploy` can see that you depend on their API. Without registration, the safety gate can't protect you.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-import { ContractValidator } from "@sahina/cvt-sdk";
-import { createMockAdapter } from "@sahina/cvt-sdk/adapters";
-
-const validator = new ContractValidator("localhost:9550");
-await validator.registerSchema("petstore", "./openapi.json");
-
-// Create mock adapter to capture interactions
-const mock = createMockAdapter({ validator, cache: true });
-
-// Run tests using the mock
-await mock.fetch("http://mock.petstore/pet/123");
-await mock.fetch("http://mock.petstore/pet", { method: "POST", body: "{}" });
-
-// Auto-register consumer from captured interactions
-const consumerInfo = await validator.registerConsumerFromInteractions(
-  mock.getInteractions(),
-  {
-    consumerId: "order-service",
-    consumerVersion: "2.1.0",
-    environment: "dev",
-    schemaVersion: "1.0.0",
-    // schemaId auto-extracted from URL: http://mock.petstore/... -> "petstore"
-  },
-);
-
-console.log(
-  `Registered ${consumerInfo.consumerId} with ${consumerInfo.usedEndpoints.length} endpoints`,
-);
-validator.close();
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-// Use interactions captured from MockingRoundTripper or HTTP adapter
-interactions := mock.GetInteractions()
-
-consumerInfo, err := validator.RegisterConsumerFromInteractions(ctx, interactions, cvt.AutoRegisterConfig{
-    ConsumerID:      "order-service",
-    ConsumerVersion: "2.1.0",
-    Environment:     "dev",
-    SchemaVersion:   "1.0.0",
-    // SchemaID is auto-extracted from URL: http://mock.petstore/... -> "petstore"
-})
-if err != nil {
-    log.Fatal(err)
-}
-
-fmt.Printf("Registered %s with %d endpoints\n", consumerInfo.ConsumerID, len(consumerInfo.UsedEndpoints))
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-from cvt_sdk import ContractValidator
-from cvt_sdk.adapters import create_mock_session
-
-validator = ContractValidator('localhost:9550')
-validator.register_schema('petstore', './openapi.json')
-
-# Create mock session to capture interactions
-mock = create_mock_session(validator=validator, cache=True)
-
-# Run tests using the mock
-mock.get('http://mock.petstore/pet/123')
-mock.post('http://mock.petstore/pet', json={})
-
-# Auto-register consumer from captured interactions
-from cvt_sdk import AutoRegisterConfig
-
-consumer_info = validator.register_consumer_from_interactions(
-    mock.get_interactions(),
-    AutoRegisterConfig(
-        consumer_id='order-service',
-        consumer_version='2.1.0',
-        environment='dev',
-        schema_version='1.0.0',
-        # schema_id auto-extracted from URL: http://mock.petstore/... -> 'petstore'
-    ),
-)
-
-print(f"Registered {consumer_info['consumer_id']} with {len(consumer_info['used_endpoints'])} endpoints")
-validator.close()
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-import io.github.sahina.sdk.ContractValidator;
-import io.github.sahina.sdk.adapters.MockInterceptor;
-import io.github.sahina.sdk.adapters.MockConfig;
-import io.github.sahina.sdk.adapters.CapturedInteraction;
-import io.github.sahina.sdk.AutoRegisterConfig;
-import io.github.sahina.sdk.ConsumerInfo;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.MediaType;
-
-ContractValidator validator = ContractValidator.builder()
-    .address("localhost:9550")
-    .build();
-validator.registerSchema("petstore", "./openapi.json");
-
-// Create mock interceptor to capture interactions
-MockInterceptor mock = new MockInterceptor(validator)
-    .withConfig(MockConfig.builder()
-        .cache()
-        .build());
-
-OkHttpClient client = new OkHttpClient.Builder()
-    .addInterceptor(mock)
-    .build();
-
-// Run tests using the mock
-client.newCall(new Request.Builder().url("http://mock.petstore/pet/123").build()).execute();
-client.newCall(new Request.Builder().url("http://mock.petstore/pet")
-    .post(RequestBody.create("{}", MediaType.parse("application/json"))).build()).execute();
-
-// Auto-register consumer from captured interactions
-ConsumerInfo consumerInfo = validator.registerConsumerFromInteractions(
-    mock.getInteractions(),
-    AutoRegisterConfig.builder()
-        .consumerId("order-service")
-        .consumerVersion("2.1.0")
-        .environment("dev")
-        .schemaVersion("1.0.0")
-        // schemaId auto-extracted from URL: http://mock.petstore/... -> "petstore"
-        .build()
-);
-
-System.out.printf("Registered %s with %d endpoints%n",
-    consumerInfo.getConsumerId(), consumerInfo.getUsedEndpoints().size());
-validator.close();
-```
-
-</TabItem>
-</Tabs>
-
-**Schema ID Extraction:**
-
-- Auto-extracted from mock URLs: `http://mock.petstore/pet/123` extracts `petstore`
-- Override with explicit `schemaId` when using non-mock URLs:
-
-```typescript
-const consumerInfo = await validator.registerConsumerFromInteractions(
-  interactions,
-  {
-    consumerId: "order-service",
-    consumerVersion: "2.1.0",
-    environment: "dev",
-    schemaVersion: "1.0.0",
-    schemaId: "petstore", // Explicit override for non-mock URLs
-  },
-);
-```
-
-**Benefits:**
-
-- No manual endpoint specification needed
-- Fields extracted from actual usage
-- Always in sync with test behavior
-- Less maintenance overhead
-
-### Manual Registration
-
-For fine-grained control, specify endpoints explicitly:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 await validator.registerConsumer({
@@ -817,11 +352,7 @@ await validator.registerConsumer({
       path: "/pet/{petId}",
       usedFields: ["id", "name", "status", "category.name", "tags"],
     },
-    {
-      method: "POST",
-      path: "/pet",
-      usedFields: ["id"],
-    },
+    { method: "POST", path: "/pet", usedFields: ["id"] },
   ],
 });
 ```
@@ -833,23 +364,16 @@ await validator.registerConsumer({
 from cvt_sdk import RegisterConsumerOptions, EndpointUsage
 
 validator.register_consumer(RegisterConsumerOptions(
-    consumer_id='order-service',
-    consumer_version='2.1.0',
-    schema_id='petstore',
-    schema_version='1.0.0',
-    environment='dev',
+    consumer_id="order-service",
+    consumer_version="2.1.0",
+    schema_id="petstore",
+    schema_version="1.0.0",
+    environment="dev",
     used_endpoints=[
-        EndpointUsage(
-            method='GET',
-            path='/pet/{petId}',
-            used_fields=['id', 'name', 'status', 'category.name', 'tags']
-        ),
-        EndpointUsage(
-            method='POST',
-            path='/pet',
-            used_fields=['id']
-        )
-    ]
+        EndpointUsage(method="GET", path="/pet/{petId}",
+                      used_fields=["id", "name", "status", "category.name", "tags"]),
+        EndpointUsage(method="POST", path="/pet", used_fields=["id"]),
+    ],
 ))
 ```
 
@@ -864,16 +388,9 @@ _, err := validator.RegisterConsumer(ctx, cvt.RegisterConsumerOptions{
     SchemaVersion:   "1.0.0",
     Environment:     "dev",
     UsedEndpoints: []cvt.EndpointUsage{
-        {
-            Method:     "GET",
-            Path:       "/pet/{petId}",
-            UsedFields: []string{"id", "name", "status", "category.name", "tags"},
-        },
-        {
-            Method:     "POST",
-            Path:       "/pet",
-            UsedFields: []string{"id"},
-        },
+        {Method: "GET", Path: "/pet/{petId}",
+         UsedFields: []string{"id", "name", "status", "category.name", "tags"}},
+        {Method: "POST", Path: "/pet", UsedFields: []string{"id"}},
     },
 })
 ```
@@ -882,15 +399,10 @@ _, err := validator.RegisterConsumer(ctx, cvt.RegisterConsumerOptions{
 <TabItem value="java" label="Java">
 
 ```java
-import io.github.sahina.sdk.RegisterConsumerOptions;
-import io.github.sahina.sdk.EndpointUsage;
-import java.util.Arrays;
-import java.util.List;
-
-List<EndpointUsage> endpoints = Arrays.asList(
+List<EndpointUsage> endpoints = List.of(
     new EndpointUsage("GET", "/pet/{petId}",
-        Arrays.asList("id", "name", "status", "category.name", "tags")),
-    new EndpointUsage("POST", "/pet", Arrays.asList("id"))
+        List.of("id", "name", "status", "category.name", "tags")),
+    new EndpointUsage("POST", "/pet", List.of("id"))
 );
 
 validator.registerConsumer(RegisterConsumerOptions.builder()
@@ -906,544 +418,133 @@ validator.registerConsumer(RegisterConsumerOptions.builder()
 </TabItem>
 </Tabs>
 
-**Nested Field Paths:**
+**Field paths** use dot notation — `category.name`, `category.id`. This tells the producer *which* fields you rely on, so their `can-i-deploy` can tell you only about changes that actually affect you.
 
-Use dot notation to specify nested fields in `usedFields`:
+**Idempotent** — registering the same `(consumerId, schemaId, environment)` tuple overwrites the previous record. Safe to run on every CI build.
 
-- `id` - top-level field
-- `category.name` - nested field
-- `category.id` - another nested field
+**Environments** — registration is per-environment. A consumer in `dev` doesn't protect `prod`. Most services register in each environment they deploy to.
 
-This tells CVT:
+<details>
+<summary>Auto-registration from captured interactions (no manual endpoint list)</summary>
 
-- **Who you are**: `order-service` v2.1.0
-- **What you depend on**: `petstore` v1.0.0
-- **What you use**: Specific endpoints and fields
-
-### Idempotent Registration
-
-Registering the same `(consumerId, schemaId, environment)` combination will overwrite the previous registration. This allows CI pipelines to re-register on every build without manual cleanup.
-
-### Listing Consumers
-
-Query all consumers registered for a schema:
+If you're already using the **Mock adapter** or the **HTTP adapter**, CVT can extract the endpoints and fields your tests actually touched — no hand-maintained `usedEndpoints` array.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
+
+```typescript
+const mock = createMockAdapter({ validator, cache: true });
+
+// Run your tests through the mock...
+await mock.fetch("http://mock.petstore/pet/123");
+await mock.fetch("http://mock.petstore/pet", { method: "POST", body: "{}" });
+
+// ...then auto-register from what happened
+const consumerInfo = await validator.registerConsumerFromInteractions(
+  mock.getInteractions(),
+  {
+    consumerId: "order-service",
+    consumerVersion: "2.1.0",
+    environment: "dev",
+    schemaVersion: "1.0.0",
+    // schemaId auto-extracted from `http://mock.<schemaId>/...`
+  },
+);
+
+console.log(`Registered ${consumerInfo.consumerId} with ${consumerInfo.usedEndpoints.length} endpoints`);
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+from cvt_sdk import AutoRegisterConfig
+
+mock = create_mock_session(validator=validator, cache=True)
+mock.get("http://mock.petstore/pet/123")
+mock.post("http://mock.petstore/pet", json={})
+
+consumer_info = validator.register_consumer_from_interactions(
+    mock.get_interactions(),
+    AutoRegisterConfig(
+        consumer_id="order-service",
+        consumer_version="2.1.0",
+        environment="dev",
+        schema_version="1.0.0",
+    ),
+)
+```
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+```go
+interactions := mock.GetInteractions()
+
+consumerInfo, err := validator.RegisterConsumerFromInteractions(ctx, interactions, cvt.AutoRegisterConfig{
+    ConsumerID:      "order-service",
+    ConsumerVersion: "2.1.0",
+    Environment:     "dev",
+    SchemaVersion:   "1.0.0",
+})
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+ConsumerInfo consumerInfo = validator.registerConsumerFromInteractions(
+    mock.getInteractions(),
+    AutoRegisterConfig.builder()
+        .consumerId("order-service")
+        .consumerVersion("2.1.0")
+        .environment("dev")
+        .schemaVersion("1.0.0")
+        .build()
+);
+```
+
+</TabItem>
+</Tabs>
+
+Benefits: no hand-maintained endpoint list, fields pulled from real usage, always in sync with test behavior. For non-mock URLs, pass an explicit `schemaId` in the config.
+
+</details>
+
+<details>
+<summary>Listing and deregistering consumers</summary>
 
 ```typescript
 const consumers = await validator.listConsumers("petstore", "dev");
-console.log(`${consumers.length} services depend on petstore`);
-```
+// [{ consumerId: "order-service", consumerVersion: "2.1.0", ... }, ...]
 
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-consumers = validator.list_consumers('petstore', 'dev')
-print(f"{len(consumers)} services depend on petstore")
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-consumers, _ := validator.ListConsumers(ctx, "petstore", "dev")
-fmt.Printf("%d services depend on petstore\n", len(consumers))
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-List<ConsumerInfo> consumers = validator.listConsumers("petstore", "dev");
-System.out.printf("%d services depend on petstore%n", consumers.size());
-```
-
-</TabItem>
-</Tabs>
-
-### Deregistering Consumers
-
-Remove a consumer registration when no longer needed:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
 await validator.deregisterConsumer("order-service", "petstore", "dev");
 ```
 
-</TabItem>
-<TabItem value="python" label="Python">
+Python / Go / Java expose the same shape (`list_consumers`, `ListConsumers`, `listConsumers` / `deregister_consumer`, `DeregisterConsumer`, `deregisterConsumer`).
 
-```python
-validator.deregister_consumer('order-service', 'petstore', 'dev')
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-validator.DeregisterConsumer(ctx, "order-service", "petstore", "dev")
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-validator.deregisterConsumer("order-service", "petstore", "dev");
-```
-
-</TabItem>
-</Tabs>
+</details>
 
 ---
 
-## Deployment Safety (can-i-deploy)
+## Related
 
-Before deploying a new schema version, use `can-i-deploy` to check if it will break any registered consumers. For complete CLI usage, SDK examples, output formats, and version pinning details, see the [Breaking Changes Guide](./breaking-changes.mdx#deployment-safety-can-i-deploy).
+- **[Producer Testing Guide](./producer-testing.mdx)** — the other side of the handshake.
+- **[CanIDeploy](./can-i-deploy.mdx)** — the safety gate that uses what you just registered.
+- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** — wiring all this into GitHub Actions, GitLab, or Jenkins.
+- **[Configuration Reference → SDK client config](../reference/configuration.mdx#sdk-client-configuration)** — TLS, API keys, proxies.
 
----
+<details>
+<summary>Troubleshooting</summary>
 
-## Environment Promotion
+**"Failed to create validator"** — is the CVT server running? Check `docker ps` / `make up`.
 
-For environment promotion workflows (dev -> staging -> prod) and safety checks before promotion, see the [Breaking Changes Guide](./breaking-changes.mdx#environment-promotion).
+**"Schema not found"** — register it first: `await validator.registerSchema("my-api", "./openapi.json")`. In production, the producer's CI should already have registered it.
 
----
+**"Path not found"** — the path in your test must match the OpenAPI spec template. Use concrete values (`/pet/123`), not template placeholders (`/pet/{petId}`). Double-check the HTTP method matches too.
 
-## Secure Connections
+**Connection refused** — default SDK target is `localhost:9550`. Pass a different address to the constructor if your server is elsewhere.
 
-For TLS configuration and API key authentication in SDK clients, see the [Configuration Reference](../reference/configuration.mdx#sdk-client-configuration).
+**Resource cleanup** — always `.close()` the validator (or use `defer` / try-with-resources / pytest fixtures) to release gRPC connections.
 
----
-
-## Testing Scenarios
-
-### Valid Interaction
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-it("returns valid response with all required fields", async () => {
-  const result = await validator.validate(
-    { method: "GET", path: "/pet/123" },
-    {
-      statusCode: 200,
-      body: { id: 123, name: "Fluffy", status: "available", photoUrls: [] },
-    },
-  );
-  expect(result.valid).toBe(true);
-  expect(result.errors).toHaveLength(0);
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-def test_returns_valid_response_with_all_required_fields(validator):
-    result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/123'},
-        response={
-            'status_code': 200,
-            'body': {'id': 123, 'name': 'Fluffy', 'status': 'available', 'photoUrls': []}
-        }
-    )
-    assert result['valid'] is True
-    assert len(result['errors']) == 0
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-func TestReturnsValidResponseWithAllRequiredFields(t *testing.T) {
-    result, err := validator.Validate(ctx, cvt.ValidationRequest{
-        Method: "GET",
-        Path:   "/pet/123",
-    }, cvt.ValidationResponse{
-        StatusCode: 200,
-        Body: map[string]any{
-            "id": 123, "name": "Fluffy", "status": "available", "photoUrls": []any{},
-        },
-    })
-    assert.NoError(t, err)
-    assert.True(t, result.Valid)
-    assert.Empty(t, result.Errors)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-@Test
-void returnsValidResponseWithAllRequiredFields() {
-    ValidationResult result = validator.validate(
-        ValidationRequest.builder().method("GET").path("/pet/123").build(),
-        ValidationResponse.builder()
-            .statusCode(200)
-            .body("{\"id\": 123, \"name\": \"Fluffy\", \"status\": \"available\", \"photoUrls\": []}")
-            .build()
-    );
-    assertTrue(result.isValid());
-    assertTrue(result.getErrors().isEmpty());
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Invalid Response (Missing Fields)
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-it("catches missing required fields", async () => {
-  const result = await validator.validate(
-    { method: "GET", path: "/pet/123" },
-    {
-      statusCode: 200,
-      body: { id: 123 }, // missing name and photoUrls (required)
-    },
-  );
-  expect(result.valid).toBe(false);
-  // Errors are full descriptive messages, use pattern matching
-  expect(result.errors.some((e) => e.includes("name"))).toBe(true);
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-def test_catches_missing_required_fields(validator):
-    result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/123'},
-        response={
-            'status_code': 200,
-            'body': {'id': 123}  # missing name and photoUrls (required)
-        }
-    )
-    assert result['valid'] is False
-    # Errors are full descriptive messages, use pattern matching
-    assert any('name' in e for e in result['errors'])
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-func TestCatchesMissingRequiredFields(t *testing.T) {
-    result, err := validator.Validate(ctx, cvt.ValidationRequest{
-        Method: "GET",
-        Path:   "/pet/123",
-    }, cvt.ValidationResponse{
-        StatusCode: 200,
-        Body:       map[string]any{"id": 123}, // missing name and photoUrls (required)
-    })
-    assert.NoError(t, err)
-    assert.False(t, result.Valid)
-    // Errors are full descriptive messages, use pattern matching
-    hasNameError := false
-    for _, e := range result.Errors {
-        if strings.Contains(e, "name") {
-            hasNameError = true
-            break
-        }
-    }
-    assert.True(t, hasNameError)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-@Test
-void catchesMissingRequiredFields() {
-    ValidationResult result = validator.validate(
-        ValidationRequest.builder().method("GET").path("/pet/123").build(),
-        ValidationResponse.builder()
-            .statusCode(200)
-            .body("{\"id\": 123}")  // missing name and photoUrls (required)
-            .build()
-    );
-    assertFalse(result.isValid());
-    // Errors are full descriptive messages, use pattern matching
-    assertTrue(result.getErrors().stream().anyMatch(e -> e.contains("name")));
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Error Responses
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-it("validates 404 error response format", async () => {
-  const result = await validator.validate(
-    { method: "GET", path: "/pet/nonexistent" },
-    {
-      statusCode: 404,
-      body: {},
-    },
-  );
-  // Valid if 404 response matches schema's 404 response definition
-  expect(result.valid).toBe(true);
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-def test_validates_404_error_response_format(validator):
-    result = validator.validate(
-        request={'method': 'GET', 'path': '/pet/nonexistent'},
-        response={
-            'status_code': 404,
-            'body': {}
-        }
-    )
-    # Valid if 404 response matches schema's 404 response definition
-    assert result['valid'] is True
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-func TestValidates404ErrorResponseFormat(t *testing.T) {
-    result, err := validator.Validate(ctx, cvt.ValidationRequest{
-        Method: "GET",
-        Path:   "/pet/nonexistent",
-    }, cvt.ValidationResponse{
-        StatusCode: 404,
-        Body:       map[string]any{},
-    })
-    assert.NoError(t, err)
-    // Valid if 404 response matches schema's 404 response definition
-    assert.True(t, result.Valid)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-@Test
-void validates404ErrorResponseFormat() {
-    ValidationResult result = validator.validate(
-        ValidationRequest.builder().method("GET").path("/pet/nonexistent").build(),
-        ValidationResponse.builder()
-            .statusCode(404)
-            .body("{}")
-            .build()
-    );
-    // Valid if 404 response matches schema's 404 response definition
-    assertTrue(result.isValid());
-}
-```
-
-</TabItem>
-</Tabs>
-
----
-
-## CI/CD Integration
-
-For complete CI/CD pipeline examples (GitHub Actions, GitLab CI, Jenkins) including contract testing, consumer registration, and deployment safety checks, see the [CI/CD Integration Guide](./ci-cd-integration.mdx).
-
----
-
-## Corporate Proxy Configuration
-
-For proxy configuration including gRPC traffic, HTTP traffic, SDK-specific settings, and SSL certificate issues, see the [Configuration Reference](../reference/configuration.mdx#proxy-configuration).
-
----
-
-## Troubleshooting
-
-### "Failed to create validator"
-
-Make sure CVT server is running:
-
-```bash
-make up
-# or
-docker-compose up -d cvt-server
-```
-
-### "Schema not found"
-
-Ensure the schema is registered before validation:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-// Register schema first
-await validator.registerSchema("my-api", "./openapi.json");
-
-// Then validate
-const result = await validator.validate(request, response);
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-# Register schema first
-validator.register_schema('my-api', './openapi.json')
-
-# Then validate
-result = validator.validate(request, response)
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-// Register schema first
-validator.RegisterSchema(ctx, "my-api", "./openapi.json")
-
-// Then validate
-result, _ := validator.Validate(ctx, request, response)
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Register schema first
-validator.registerSchema("my-api", "./openapi.json");
-
-// Then validate
-ValidationResult result = validator.validate(request, response);
-```
-
-</TabItem>
-</Tabs>
-
-### "Path not found"
-
-Check that your path matches the OpenAPI spec:
-
-- Use actual path values: `/pet/123` not `/pet/{petId}`
-- Ensure the HTTP method matches
-
-### Connection refused
-
-Default server address is `localhost:9550`. Configure if different:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-const validator = new ContractValidator("cvt.internal:9550");
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-validator = ContractValidator('cvt.internal:9550')
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-validator, _ := cvt.NewValidator("cvt.internal:9550")
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-ContractValidator validator = new ContractValidator("cvt.internal:9550");
-```
-
-</TabItem>
-</Tabs>
-
-### Resource cleanup
-
-Always close the validator when done to release gRPC connections:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-// In tests
-afterAll(() => validator.close());
-
-// In application code
-try {
-  await validator.registerSchema("my-api", "./openapi.json");
-  // ... use validator
-} finally {
-  validator.close();
-}
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-# In tests (using pytest fixture)
-@pytest.fixture
-def validator():
-    v = ContractValidator('localhost:9550')
-    yield v
-    v.close()
-
-# In application code
-try:
-    validator.register_schema('my-api', './openapi.json')
-    # ... use validator
-finally:
-    validator.close()
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-// Use defer for automatic cleanup
-validator, _ := cvt.NewValidator("localhost:9550")
-defer validator.Close()
-
-// ... use validator
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Use try-with-resources for automatic cleanup
-try (ContractValidator validator = new ContractValidator("localhost:9550")) {
-    validator.registerSchema("my-api", "./openapi.json");
-    // ... use validator
-}
-```
-
-</TabItem>
-</Tabs>
-
----
-
-## Next Steps
-
-- **[Producer Testing Guide](./producer-testing.mdx)** - Validate your own APIs
-- **[Breaking Changes Guide](./breaking-changes.mdx)** - Understand schema compatibility
-- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** - Pipeline examples for contract testing
-- **[Validation Modes](./validation-modes.mdx)** - Configure validation behavior
-- **[API Reference](../reference/api.mdx)** - Full API documentation
+</details>

--- a/docs/guides/producer-testing.mdx
+++ b/docs/guides/producer-testing.mdx
@@ -10,116 +10,33 @@ import TabItem from "@theme/TabItem";
 
 # Producer Testing Guide
 
-This guide covers how to use CVT for producer-side contract testing. Producer testing ensures your API implementation matches your OpenAPI specification before deployment.
+Producer testing answers: **"Does my API actually return what my spec promises?"** This is Bob's side of the handshake — the consumer side is in [Consumer Testing](./consumer-testing.mdx). If you're new to CVT, read the [Introduction](../intro.md) first.
 
-:::tip Example Schema
-The examples in this guide use the Petstore schema from `sdks/shared/openapi.json`. Copy it to your project as `openapi.json` or adjust the paths to reference it directly.
+As the producer you own the OpenAPI spec; your CI should register it with the shared CVT server so consumers can validate against it and [`can-i-deploy`](./can-i-deploy.mdx) can gate your releases.
 
-All `registerSchema` methods accept both **file paths** and **URLs**:
+## Approaches at a glance
 
-```typescript
-// From file
-await validator.registerSchema("petstore", "./openapi.json");
-// From URL
-await validator.registerSchema(
-  "petstore",
-  "https://petstore3.swagger.io/api/v3/openapi.json",
-);
-```
+| Approach | How it works | Runs where | Speed | Best for |
+|---|---|---|---|---|
+| **Schema compliance tests** | Unit-test handlers against the spec using `ProducerTestKit` | Your test suite | Fast | Fast feedback during dev; CI |
+| **Middleware** (strict/warn/shadow) | CVT middleware validates real requests + responses in your running API | Your API server | Per-request overhead | Runtime enforcement; production rollout |
+| **HTTP integration** | End-to-end HTTP calls into your running API, validated by CVT | Integration test suite | Medium | Routing / serialization bugs |
 
-:::
-
-## Overview
-
-Producer testing answers the question: **"Does my API match my spec?"**
-
-:::tip Producer Owns the Schema
-As the producer, **you own the OpenAPI spec** — it is the source of truth for your API's contract. Your CI/CD pipeline should register the schema with the shared CVT server so that consumers can validate against it and register their dependencies. This enables deployment safety via `can-i-deploy`. See [Schema Registration in CI/CD](#schema-registration-in-cicd) below.
-:::
-
-| Approach             | Who Uses It   | What It Tests                    |
-| -------------------- | ------------- | -------------------------------- |
-| **Consumer Testing** | API consumers | "Can I call this API correctly?" |
-| **Producer Testing** | API producers | "Does my API match my spec?"     |
-
-```text
-┌─────────────────────┐     HTTP      ┌─────────────────────┐
-│   Client Requests   │ ────────────► │   Your API Server   │
-└─────────────────────┘               │   + CVT Middleware  │
-                                      └─────────────────────┘
-                                               │
-                                               │ Validate
-                                               ▼
-                                      ┌─────────────────────┐
-                                      │    CVT Server       │
-                                      │    + Your Schema    │
-                                      └─────────────────────┘
-```
+Most teams use all three: compliance tests in unit-test CI, middleware in staging+prod, HTTP integration in a pre-deploy job.
 
 ---
 
-## Capabilities
+## Schema compliance testing
 
-| Capability                    | Server Required? | What It Answers                                    |
-| ----------------------------- | ---------------- | -------------------------------------------------- |
-| **Schema compliance tests**   | Yes              | "Does my handler return spec-compliant responses?" |
-| **Breaking change detection** | No (CLI)         | "What changed between v1 and v2 of my spec?"       |
-| **Consumer registry**         | Yes              | "Which services depend on my API?"                 |
-| **can-i-deploy**              | Yes              | "Will this change break real consumers?"           |
-
----
-
-## Validation Approaches
-
-| Test Type             | Services Required | Speed  | Purpose                           |
-| --------------------- | ----------------- | ------ | --------------------------------- |
-| **Schema Compliance** | CVT only          | Fast   | Unit test handlers against schema |
-| **Middleware Modes**  | CVT only          | Fast   | Test Strict/Warn/Shadow behavior  |
-| **Consumer Registry** | CVT only          | Fast   | can-i-deploy checks               |
-| **HTTP Integration**  | Producer + CVT    | Medium | Full end-to-end validation        |
-
-- **Schema Compliance**: Test handlers directly without running a server. Fast feedback during development.
-- **Middleware Modes**: CVT middleware validates requests/responses in real-time. Three modes for different stages.
-- **Consumer Registry**: Track which endpoints consumers use. Enables `can-i-deploy` safety checks.
-- **HTTP Integration**: Real HTTP calls to running API. Tests complete stack including routing/serialization.
-
----
-
-## Schema Compliance Testing
-
-Schema compliance testing validates that your API handlers return responses matching your OpenAPI specification.
-
-### How It Works
-
-```mermaid
-sequenceDiagram
-    participant Test as Your Test
-    participant Handler as API Handler
-    participant TestKit as ProducerTestKit
-    participant CVT as CVT Server
-
-    Test->>Handler: Call handler
-    Handler-->>Test: Response
-    Test->>TestKit: validateResponse(response)
-    TestKit->>CVT: ValidateProducerResponse
-    CVT-->>TestKit: ValidationResult
-    TestKit-->>Test: Result (valid/errors)
-```
-
-1. Register your OpenAPI schema with CVT server
-2. Call your handler with test data
-3. Validate the response against the schema
-4. Get detailed error messages for any mismatches
-
-### Basic Example
+Call your handler, validate its response against the spec. No running HTTP server, no middleware — just the handler and CVT.
 
 <Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 import { ProducerTestKit } from "@sahina/cvt-sdk/producer";
 
-describe("Petstore API", () => {
+describe("Pets API", () => {
   let testKit: ProducerTestKit;
 
   beforeAll(async () => {
@@ -129,36 +46,25 @@ describe("Petstore API", () => {
     });
   });
 
-  afterAll(async () => {
-    testKit.close();
-  });
+  afterAll(async () => testKit.close());
 
-  it("GET /pet/{petId} returns valid response", async () => {
-    // Call your actual handler
+  it("GET /pet/{petId} returns a valid response", async () => {
     const response = await petHandler.getPet("123");
 
-    // Validate against schema
     const result = await testKit.validateResponse({
       method: "GET",
       path: "/pet/123",
-      response: {
-        statusCode: 200,
-        body: response,
-      },
+      response: { statusCode: 200, body: response },
     });
 
     expect(result.valid).toBe(true);
-    expect(result.errors).toHaveLength(0);
   });
 
   it("detects missing required fields", async () => {
     const result = await testKit.validateResponse({
       method: "GET",
       path: "/pet/123",
-      response: {
-        statusCode: 200,
-        body: { id: 123 }, // missing 'name' and 'photoUrls' fields
-      },
+      response: { statusCode: 200, body: { id: 123 } }, // no name, no photoUrls
     });
 
     expect(result.valid).toBe(false);
@@ -184,28 +90,19 @@ def test_kit():
     kit.close()
 
 def test_get_pet_returns_valid_response(test_kit, pet_handler):
-    # Call your handler
     response = pet_handler.get_pet("123")
 
-    # Validate
     result = test_kit.validate_response(
-        method="GET",
-        path="/pet/123",
-        status_code=200,
-        body=response,
+        method="GET", path="/pet/123",
+        status_code=200, body=response,
     )
-
     assert result.valid
-    assert len(result.errors) == 0
 
 def test_detects_missing_required_fields(test_kit):
     result = test_kit.validate_response(
-        method="GET",
-        path="/pet/123",
-        status_code=200,
-        body={"id": 123},  # missing 'name' and 'photoUrls' fields
+        method="GET", path="/pet/123",
+        status_code=200, body={"id": 123},
     )
-
     assert not result.valid
     assert "name" in result.errors[0]
 ```
@@ -215,42 +112,30 @@ def test_detects_missing_required_fields(test_kit):
 
 ```go
 func TestPetHandler(t *testing.T) {
-    testKit, err := producer.NewProducerTestKit(producer.TestConfig{
+    testKit, _ := producer.NewProducerTestKit(producer.TestConfig{
         SchemaID:      "petstore",
         ServerAddress: "localhost:9550",
     })
-    require.NoError(t, err)
-    defer func() { _ = testKit.Close() }()
+    defer testKit.Close()
 
     t.Run("GET /pet/{petId} returns valid response", func(t *testing.T) {
-        // Call your handler
         resp := petHandler.GetPet(ctx, "123")
 
-        // Validate
-        result, err := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
-            Method: "GET",
-            Path:   "/pet/123",
-            Response: producer.TestResponseData{
-                StatusCode: 200,
-                Body:       resp,
-            },
+        result, _ := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
+            Method: "GET", Path: "/pet/123",
+            Response: producer.TestResponseData{StatusCode: 200, Body: resp},
         })
-
-        require.NoError(t, err)
         assert.True(t, result.Valid)
     })
 
     t.Run("detects missing required fields", func(t *testing.T) {
-        result, err := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
-            Method: "GET",
-            Path:   "/pet/123",
+        result, _ := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
+            Method: "GET", Path: "/pet/123",
             Response: producer.TestResponseData{
                 StatusCode: 200,
-                Body:       map[string]any{"id": 123}, // missing 'name' and 'photoUrls' fields
+                Body:       map[string]any{"id": 123},
             },
         })
-
-        require.NoError(t, err)
         assert.False(t, result.Valid)
     })
 }
@@ -272,39 +157,24 @@ public class PetHandlerTest {
     }
 
     @AfterEach
-    void teardown() {
-        testKit.close();
-    }
+    void teardown() { testKit.close(); }
 
     @Test
     void getPetReturnsValidResponse() {
-        // Call your handler
         var response = petHandler.getPet("123");
 
-        // Validate
-        var result = testKit.validateResponse(
-            "GET",
-            "/pet/123",
-            TestResponseData.builder()
-                .statusCode(200)
-                .body(response)
-                .build()
-        );
+        var result = testKit.validateResponse("GET", "/pet/123",
+            TestResponseData.builder().statusCode(200).body(response).build());
 
         assertTrue(result.isValid());
-        assertTrue(result.getErrors().isEmpty());
     }
 
     @Test
     void detectsMissingRequiredFields() {
-        var result = testKit.validateResponse(
-            "GET",
-            "/pet/123",
+        var result = testKit.validateResponse("GET", "/pet/123",
             TestResponseData.builder()
-                .statusCode(200)
-                .body(Map.of("id", 123))  // missing 'name' and 'photoUrls' fields
-                .build()
-        );
+                .statusCode(200).body(Map.of("id", 123))
+                .build());
 
         assertFalse(result.isValid());
         assertTrue(result.getErrors().get(0).contains("name"));
@@ -315,44 +185,65 @@ public class PetHandlerTest {
 </TabItem>
 </Tabs>
 
----
-
-## Producer Middleware
-
-For runtime validation, add CVT middleware to your HTTP server.
-
-### How Middleware Works
+<details>
+<summary>How schema compliance testing works under the hood</summary>
 
 ```mermaid
 sequenceDiagram
-    participant Client as Client Request
-    participant MW as CVT Middleware
+    participant Test as Your Test
+    participant Handler as API Handler
+    participant TestKit as ProducerTestKit
     participant CVT as CVT Server
-    participant Handler as Your API Handler
 
-    Client->>MW: HTTP Request
-    MW->>CVT: Validate request
-    CVT-->>MW: ValidationResult
-    alt Request Valid
-        MW->>Handler: Forward request
-        Handler-->>MW: Response
-        MW->>CVT: Validate response
-        CVT-->>MW: ValidationResult
-        alt Response Valid
-            MW-->>Client: Return response
-        else Response Invalid
-            Note over MW: Log error (response already sent)
-            MW-->>Client: Return response
-        end
-    else Request Invalid
-        MW-->>Client: 400 Bad Request
-    end
+    Test->>Handler: Call handler
+    Handler-->>Test: Response
+    Test->>TestKit: validateResponse(response)
+    TestKit->>CVT: ValidateProducerResponse
+    CVT-->>TestKit: ValidationResult
+    TestKit-->>Test: Result (valid/errors)
 ```
 
-### Framework Examples
+TestKit talks to the CVT server over gRPC; CVT validates the response body, headers, and status code against the registered schema; errors come back as a list of specific violations.
 
-<Tabs groupId="producer-framework">
-<TabItem value="express" label="Express">
+</details>
+
+<details>
+<summary>Testing all response codes (200, 4xx, 5xx), not just the happy path</summary>
+
+Error responses have their own schemas. Validate them too:
+
+```typescript
+it("validates 404 response", async () => {
+  const result = await testKit.validateResponse({
+    method: "GET",
+    path: "/pet/nonexistent",
+    response: { statusCode: 404, body: {} },
+  });
+  expect(result.valid).toBe(true);
+});
+
+it("validates 400 response for bad request", async () => {
+  const result = await testKit.validateResponse({
+    method: "POST",
+    path: "/pet",
+    response: { statusCode: 400, body: {} },
+  });
+  expect(result.valid).toBe(true);
+});
+```
+
+Same pattern in Python / Go / Java with the respective `validateResponse` signatures.
+
+</details>
+
+---
+
+## Middleware: runtime validation in your running API
+
+Add CVT middleware to your HTTP server — every request and response is validated against the schema in real time. Middleware has three [validation modes](./validation-modes.mdx): `shadow` (metrics only), `warn` (log), `strict` (reject). Roll out shadow → warn → strict.
+
+<Tabs groupId="sdk-language">
+<TabItem value="nodejs" label="Node.js" default>
 
 ```typescript
 import { createExpressMiddleware } from "@sahina/cvt-sdk/producer";
@@ -361,44 +252,13 @@ app.use(
   createExpressMiddleware({
     schemaId: "petstore",
     validator,
-    mode: "strict", // or 'warn' or 'shadow'
+    mode: "strict", // or "warn" or "shadow"
   }),
 );
 ```
 
 </TabItem>
-<TabItem value="fastify" label="Fastify">
-
-```typescript
-import { fastifyProducerPlugin } from "@sahina/cvt-sdk/producer";
-
-fastify.register(fastifyProducerPlugin, { schemaId: "petstore", validator });
-```
-
-</TabItem>
-<TabItem value="go-http" label="Go net/http">
-
-```go
-import "github.com/sahina/cvt/sdks/go/cvt/producer/adapters"
-
-config := producer.Config{
-    SchemaID:  "petstore",
-    Validator: validator,
-    Mode:      producer.ModeStrict,
-}
-http.Handle("/", adapters.NetHTTPMiddleware(config)(myHandler))
-```
-
-</TabItem>
-<TabItem value="gin" label="Gin">
-
-```go
-router := gin.Default()
-router.Use(adapters.GinMiddleware(config))
-```
-
-</TabItem>
-<TabItem value="fastapi" label="FastAPI">
+<TabItem value="python" label="Python">
 
 ```python
 from cvt_sdk.producer import ProducerConfig, ValidationMode
@@ -413,18 +273,22 @@ app.add_middleware(ASGIMiddleware, config=config)
 ```
 
 </TabItem>
-<TabItem value="flask" label="Flask">
+<TabItem value="go" label="Go">
 
-```python
-from cvt_sdk.producer.adapters import WSGIMiddleware
-
-app.wsgi_app = WSGIMiddleware(app.wsgi_app, config=config)
+```go
+config := producer.Config{
+    SchemaID:  "petstore",
+    Validator: validator,
+    Mode:      producer.ModeStrict,
+}
+http.Handle("/", adapters.NetHTTPMiddleware(config)(myHandler))
 ```
 
 </TabItem>
-<TabItem value="spring" label="Spring">
+<TabItem value="java" label="Java">
 
 ```java
+// Spring
 registry.addInterceptor(new SpringInterceptor(config))
     .addPathPatterns("/api/**");
 ```
@@ -432,12 +296,50 @@ registry.addInterceptor(new SpringInterceptor(config))
 </TabItem>
 </Tabs>
 
-### Path Filtering
+For the three modes and the recommended rollout, see **[Validation Modes](./validation-modes.mdx)**.
 
-Exclude health checks, metrics, or other paths from validation:
+<details>
+<summary>Other framework adapters (Fastify, Gin, Flask, FastAPI, Spring…)</summary>
 
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+<Tabs groupId="producer-framework">
+<TabItem value="fastify" label="Fastify">
+
+```typescript
+import { fastifyProducerPlugin } from "@sahina/cvt-sdk/producer";
+fastify.register(fastifyProducerPlugin, { schemaId: "petstore", validator });
+```
+
+</TabItem>
+<TabItem value="gin" label="Gin">
+
+```go
+router := gin.Default()
+router.Use(adapters.GinMiddleware(config))
+```
+
+</TabItem>
+<TabItem value="fastapi" label="FastAPI">
+
+```python
+from cvt_sdk.producer.adapters import ASGIMiddleware
+app.add_middleware(ASGIMiddleware, config=config)
+```
+
+</TabItem>
+<TabItem value="flask" label="Flask">
+
+```python
+from cvt_sdk.producer.adapters import WSGIMiddleware
+app.wsgi_app = WSGIMiddleware(app.wsgi_app, config=config)
+```
+
+</TabItem>
+</Tabs>
+
+</details>
+
+<details>
+<summary>Excluding health checks and metrics paths from validation</summary>
 
 ```typescript
 createExpressMiddleware({
@@ -449,283 +351,34 @@ createExpressMiddleware({
 });
 ```
 
-</TabItem>
-<TabItem value="python" label="Python">
+Python / Go / Java configs have matching `excludePaths` / `includePaths` fields.
 
-```python
-config = ProducerConfig(
-    schema_id="petstore",
-    validator=validator,
-    mode=ValidationMode.STRICT,
-    exclude_paths=["/health", "/metrics", "/ready"],
-    include_paths=["/api/**"],
-)
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-config := producer.Config{
-    SchemaID:     "petstore",
-    Validator:    validator,
-    Mode:         producer.ModeStrict,
-    ExcludePaths: []string{"/health", "/metrics", "/ready"},
-    IncludePaths: []string{"/api/**"},
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-ProducerConfig config = ProducerConfig.builder()
-    .schemaId("petstore")
-    .validator(validator)
-    .mode(ValidationMode.STRICT)
-    .excludePaths(List.of("/health", "/metrics", "/ready"))
-    .includePaths(List.of("/api/**"))
-    .build();
-```
-
-</TabItem>
-</Tabs>
+</details>
 
 ---
 
-## Validation Modes
+## Fixture generation
 
-See [Validation Modes](./validation-modes.mdx) for detailed information.
-
-| Mode       | Request Violation | Response Violation | Use Case               |
-| ---------- | ----------------- | ------------------ | ---------------------- |
-| **strict** | Reject with 400   | Log error          | Production enforcement |
-| **warn**   | Log, continue     | Log, continue      | Gradual rollout        |
-| **shadow** | Silent            | Silent             | Initial deployment     |
-
-### Recommended Rollout
-
-```text
-Deploy with SHADOW → Analyze metrics → Switch to WARN → Fix issues → Switch to STRICT
-```
-
----
-
-## Consumer Registry
-
-Track which services depend on your API.
-
-### Listing Your Consumers
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-const consumers = await validator.listConsumers("petstore", "prod");
-
-console.log(`${consumers.length} services depend on petstore in prod`);
-for (const consumer of consumers) {
-  console.log(`- ${consumer.consumerId} v${consumer.consumerVersion}`);
-}
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-consumers = validator.list_consumers("petstore", "prod")
-
-print(f"{len(consumers)} services depend on petstore in prod")
-for consumer in consumers:
-    print(f"- {consumer['consumer_id']} v{consumer['consumer_version']}")
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-consumers, err := validator.ListConsumers(ctx, "petstore", "prod")
-if err != nil {
-    log.Fatal(err)
-}
-
-fmt.Printf("%d services depend on petstore in prod\n", len(consumers))
-for _, consumer := range consumers {
-    fmt.Printf("- %s v%s\n", consumer.ConsumerID, consumer.ConsumerVersion)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-List<ConsumerInfo> consumers = validator.listConsumers("petstore", "prod");
-
-System.out.printf("%d services depend on petstore in prod%n", consumers.size());
-for (ConsumerInfo consumer : consumers) {
-    System.out.printf("- %s v%s%n", consumer.getConsumerId(), consumer.getConsumerVersion());
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Understanding Consumer Registrations
-
-Consumers register after their contract tests pass:
-
-```typescript
-// A consumer (not you) registers like this:
-await validator.registerConsumer({
-  consumerId: "order-service",
-  consumerVersion: "2.1.0",
-  schemaId: "petstore", // Your API
-  schemaVersion: "1.0.0",
-  environment: "prod",
-  usedEndpoints: [
-    {
-      method: "GET",
-      path: "/pet/{petId}",
-      usedFields: ["id", "name", "status"],
-    },
-  ],
-});
-```
-
-This tells you:
-
-- `order-service` depends on your API
-- They use `GET /pet/{petId}`
-- They specifically need the `id`, `name`, and `status` fields
-
----
-
-## Deployment Safety (can-i-deploy)
-
-Before deploying a new schema version, use `can-i-deploy` to check if it will break any registered consumers. For complete CLI usage, SDK examples, breaking change types, and output formats, see the [Breaking Changes Guide](./breaking-changes.mdx#deployment-safety-can-i-deploy).
-
----
-
-## Test Fixture Generation
-
-Generate test data from your OpenAPI schema for documentation and testing.
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-// Generate complete request/response fixture
-const fixture = await validator.generateFixture("GET", "/pet/{petId}");
-console.log(fixture.request); // { method, path, headers, body }
-console.log(fixture.response); // { statusCode, headers, body }
-
-// Generate response only with schema examples
-const response = await validator.generateResponse("GET", "/pet/{petId}", {
-  statusCode: 200,
-  useExamples: true,
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-from cvt_sdk import GenerateOptions
-
-# Generate complete request/response fixture
-fixture = validator.generate_fixture("GET", "/pet/{petId}")
-print(fixture["request"])   # { method, path, headers, body }
-print(fixture["response"])  # { status_code, headers, body }
-
-# Generate response only with schema examples
-response = validator.generate_response("GET", "/pet/{petId}",
-    GenerateOptions(status_code=200, use_examples=True),
-)
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-// Generate complete request/response fixture
-fixture, err := validator.GenerateFixture(ctx, "GET", "/pet/{petId}", nil)
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println(fixture.Request)   // { Method, Path, Headers, Body }
-fmt.Println(fixture.Response)  // { StatusCode, Headers, Body }
-
-// Generate response only with schema examples
-response, err := validator.GenerateResponse(ctx, "GET", "/pet/{petId}",
-    &cvt.GenerateOptions{
-        StatusCode:  200,
-        UseExamples: true,
-    },
-)
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Generate complete request/response fixture
-GeneratedFixture fixture = validator.generateFixture("GET", "/pet/{petId}", null);
-System.out.println(fixture.getRequest());   // { method, path, headers, body }
-System.out.println(fixture.getResponse());  // { statusCode, headers, body }
-
-// Generate response only with schema examples
-GeneratedResponse response = validator.generateResponse("GET", "/pet/{petId}",
-    GenerateOptions.builder()
-        .statusCode(200)
-        .useExamples(true)
-        .build()
-);
-```
-
-</TabItem>
-</Tabs>
-
-### CLI Usage
+Generate request/response examples directly from the schema — useful for documentation, golden tests, or bootstrapping new consumer services.
 
 ```bash
-# List all endpoints in a schema
-cvt generate --schema ./openapi.json --list
-
-# Generate fixture for an endpoint
-cvt generate --schema ./openapi.json --method GET --path /pet/{petId}
-
-# Generate request only
+cvt generate --schema ./openapi.json --list                            # list all endpoints
+cvt generate --schema ./openapi.json --method GET --path /pet/{petId}  # generate one
 cvt generate --schema ./openapi.json --method POST --path /pet --output-type request
-
-# Use examples from schema
-cvt generate --schema ./openapi.json --method GET --path /pet/{petId} --use-examples
 ```
+
+SDK equivalents exist for all languages; see [CLI Reference](../reference/cli.mdx#generate) for flags and [API Reference](../reference/api.mdx) for the SDK surface.
 
 ---
 
-## Schema Registration in CI/CD
+## Schema registration in CI/CD
 
-As the API producer, your CI/CD pipeline is responsible for registering your OpenAPI schema with the shared CVT server. This is how consumers discover your contract and how `can-i-deploy` knows what to check against.
-
-```text
-Producer CI/CD Pipeline:
-
-  Build & Test → Register Schema → Deploy
-                       │
-                       ▼
-                  CVT Server (shared)
-                       ▲
-                       │
-  Consumer CI/CD:  Validate interactions → Register as consumer
-```
-
-### Register on merge to main
+You (the producer) register your schema — consumers read it, they don't write it. Wire this into your CI so the registered schema always matches what's deployed:
 
 <Tabs groupId="sdk-language">
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 ```bash
-# In your producer CI/CD pipeline
 cvt register-schema my-api ./openapi.json \
   --version "$API_VERSION" \
   --server "$CVT_SERVER_URL" \
@@ -737,12 +390,9 @@ cvt register-schema my-api ./openapi.json \
 <TabItem value="nodejs" label="Node.js">
 
 ```typescript
-// In a CI/CD script or test setup
 const validator = new ContractValidator(process.env.CVT_SERVER_URL);
 await validator.registerSchemaWithVersion(
-  "my-api",
-  "./openapi.json",
-  process.env.API_VERSION,
+  "my-api", "./openapi.json", process.env.API_VERSION
 );
 ```
 
@@ -751,284 +401,67 @@ await validator.registerSchemaWithVersion(
 
 ```go
 validator, _ := cvt.NewValidator(os.Getenv("CVT_SERVER_URL"))
-err := validator.RegisterSchemaWithVersion(ctx, "my-api", "./openapi.json", os.Getenv("API_VERSION"))
+validator.RegisterSchemaWithVersion(ctx, "my-api", "./openapi.json", os.Getenv("API_VERSION"))
 ```
 
 </TabItem>
 </Tabs>
 
-### Why the producer must register
+Full pipeline examples (including `can-i-deploy` as a deploy gate): **[CI/CD Integration Guide](./ci-cd-integration.mdx)**.
 
-| If the producer registers...         | If the consumer registers...                       |
-| ------------------------------------ | -------------------------------------------------- |
-| Schema always matches the real API   | Schema may be stale or incorrect                   |
-| Single source of truth               | Multiple consumers may register different versions |
-| `can-i-deploy` checks are meaningful | Breaking change detection is unreliable            |
-| Clear ownership and accountability   | Unclear who maintains the contract                 |
+<details>
+<summary>Why the producer owns schema registration</summary>
+
+| If the producer registers… | If a consumer registers… |
+|---|---|
+| Schema always matches the real API | Schema may be stale or wrong |
+| Single source of truth | Multiple consumers may register different versions |
+| `can-i-deploy` is meaningful | Breaking-change detection is unreliable |
+| Clear ownership | Unclear who maintains the contract |
+
+Consumers registering for **local development** is fine — it's what the Quick Start does. In CI, the producer's pipeline should be the only writer.
+
+</details>
 
 ---
 
-## CI/CD Integration
+## Deployment safety with `can-i-deploy`
 
-For complete CI/CD pipeline examples (GitHub Actions, GitLab CI, Jenkins) including producer deployment safety checks and contract testing, see the [CI/CD Integration Guide](./ci-cd-integration.mdx).
-
----
-
-## Best Practices
-
-### 1. Test All Response Scenarios
-
-Don't just test the happy path:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-it("validates 404 response", async () => {
-  const result = await testKit.validateResponse({
-    method: "GET",
-    path: "/pet/nonexistent",
-    response: {
-      statusCode: 404,
-      body: {},
-    },
-  });
-  expect(result.valid).toBe(true);
-});
-
-it("validates 400 response for bad request", async () => {
-  const result = await testKit.validateResponse({
-    method: "POST",
-    path: "/pet",
-    response: {
-      statusCode: 400,
-      body: {},
-    },
-  });
-  expect(result.valid).toBe(true);
-});
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-def test_validates_404_response(test_kit):
-    result = test_kit.validate_response(
-        method="GET",
-        path="/pet/nonexistent",
-        status_code=404,
-        body={},
-    )
-    assert result.valid
-
-def test_validates_400_response_for_bad_request(test_kit):
-    result = test_kit.validate_response(
-        method="POST",
-        path="/pet",
-        status_code=400,
-        body={},
-    )
-    assert result.valid
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-func TestValidates404Response(t *testing.T) {
-    result, err := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
-        Method: "GET",
-        Path:   "/pet/nonexistent",
-        Response: producer.TestResponseData{
-            StatusCode: 404,
-            Body:       map[string]any{},
-        },
-    })
-    require.NoError(t, err)
-    assert.True(t, result.Valid)
-}
-
-func TestValidates400ResponseForBadRequest(t *testing.T) {
-    result, err := testKit.ValidateResponse(ctx, producer.ValidateResponseParams{
-        Method: "POST",
-        Path:   "/pet",
-        Response: producer.TestResponseData{
-            StatusCode: 400,
-            Body:       map[string]any{},
-        },
-    })
-    require.NoError(t, err)
-    assert.True(t, result.Valid)
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-@Test
-void validates404Response() {
-    var result = testKit.validateResponse(
-        "GET",
-        "/pet/nonexistent",
-        TestResponseData.builder()
-            .statusCode(404)
-            .body(Map.of())
-            .build()
-    );
-    assertTrue(result.isValid());
-}
-
-@Test
-void validates400ResponseForBadRequest() {
-    var result = testKit.validateResponse(
-        "POST",
-        "/pet",
-        TestResponseData.builder()
-            .statusCode(400)
-            .body(Map.of())
-            .build()
-    );
-    assertTrue(result.isValid());
-}
-```
-
-</TabItem>
-</Tabs>
-
-### 2. Run can-i-deploy in CI
-
-Make deployment safety checks a required gate:
+Before shipping a schema change, run [`can-i-deploy`](./can-i-deploy.mdx) to check whether any registered consumer would break. That page covers the full workflow — CI wiring, verdict interpretation, environment promotion. Summary:
 
 ```bash
-cvt can-i-deploy --schema petstore --version $NEW_VERSION --env prod || exit 1
-```
-
-### 3. Use Environment-Specific Checks
-
-Check each environment before promoting:
-
-```bash
-# Check staging first
-cvt can-i-deploy --schema petstore --version 2.0.0 --env staging
-
-# Then production
-cvt can-i-deploy --schema petstore --version 2.0.0 --env prod
-```
-
-### 4. Gradual Middleware Rollout
-
-Start with `shadow` mode, progress to `strict`:
-
-```typescript
-// Week 1: Shadow mode - metrics only
-mode: "shadow";
-
-// Week 2: Warn mode - log violations
-mode: "warn";
-
-// Week 3: Strict mode - full enforcement
-mode: "strict";
+cvt can-i-deploy --schema petstore --version $NEW_VERSION --env prod
+# Exit 0 = safe; exit 1 = blocked with affected-consumer details
 ```
 
 ---
 
-## Troubleshooting
+## Related
 
-### "Schema not found" Error
+- **[Consumer Testing](./consumer-testing.mdx)** — the other side of the handshake.
+- **[CanIDeploy](./can-i-deploy.mdx)** — pre-deploy safety gate.
+- **[Validation Modes](./validation-modes.mdx)** — strict / warn / shadow for middleware rollout.
+- **[Breaking Changes Guide](./breaking-changes.mdx)** — what counts as breaking.
+- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** — GitHub Actions, GitLab, Jenkins.
+- **[API Reference](../reference/api.mdx)** / **[CLI Reference](../reference/cli.mdx)**.
 
-Ensure the schema is registered before running producer tests:
+<details>
+<summary>Best practices</summary>
 
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
+1. **Test all response scenarios, not just 200** — schema compliance for 4xx/5xx responses catches error-handler regressions. Example above.
+2. **Gate every prod deploy on `can-i-deploy`** — `cvt can-i-deploy --schema petstore --version $NEW_VERSION --env prod || exit 1`.
+3. **Check each environment before promoting** — run `can-i-deploy` per `--env`.
+4. **Roll out middleware gradually** — `shadow` → `warn` → `strict`, days or weeks apart, watching metrics at each step.
 
-```typescript
-await validator.registerSchema("petstore", "./openapi.json");
-```
+</details>
 
-</TabItem>
-<TabItem value="python" label="Python">
+<details>
+<summary>Troubleshooting</summary>
 
-```python
-validator.register_schema("petstore", "./openapi.json")
-```
+**"Schema not found"** — register it first: `await validator.registerSchema("petstore", "./openapi.json")`. In production, the producer's CI should handle this.
 
-</TabItem>
-<TabItem value="go" label="Go">
+**"Path not found"** — your test path must match the OpenAPI template with concrete values: `/pet/123`, not `/pet/{petId}`.
 
-```go
-err := validator.RegisterSchema(ctx, "petstore", "./openapi.json")
-```
+**"No consumers registered" warning in `can-i-deploy`** — safe, expected if you're the first deploy or no consumers use `registerConsumer` yet. See [CanIDeploy troubleshooting](./can-i-deploy.mdx#no-consumers-registered).
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-validator.registerSchema("petstore", "./openapi.json");
-```
-
-</TabItem>
-</Tabs>
-
-### "Path not found" Error
-
-Check that the path in your test matches the OpenAPI spec:
-
-<Tabs groupId="sdk-language">
-<TabItem value="nodejs" label="Node.js">
-
-```typescript
-// If spec has: /pet/{petId}
-// Use actual path values:
-path: '/pet/123',  // NOT '/pet/{petId}'
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-# If spec has: /pet/{petId}
-# Use actual path values:
-path="/pet/123"  # NOT "/pet/{petId}"
-```
-
-</TabItem>
-<TabItem value="go" label="Go">
-
-```go
-// If spec has: /pet/{petId}
-// Use actual path values:
-Path: "/pet/123",  // NOT "/pet/{petId}"
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// If spec has: /pet/{petId}
-// Use actual path values:
-"/pet/123"  // NOT "/pet/{petId}"
-```
-
-</TabItem>
-</Tabs>
-
-### "No consumers registered" Warning
-
-This is normal if you're the first to deploy or if no consumers have registered:
-
-```text
-SAFE TO DEPLOY
-No consumers registered for this schema in prod.
-```
-
----
-
-## Next Steps
-
-- **[Consumer Testing Guide](./consumer-testing.mdx)** - Test your API integrations
-- **[CI/CD Integration Guide](./ci-cd-integration.mdx)** - Pipeline examples for deployment safety
-- **[Validation Modes](./validation-modes.mdx)** - Configure validation behavior
-- **[Breaking Changes Guide](./breaking-changes.mdx)** - Understand schema compatibility
-- **[API Reference](../reference/api.mdx)** - Full API documentation
+</details>

--- a/docs/guides/producer-testing.mdx
+++ b/docs/guides/producer-testing.mdx
@@ -289,6 +289,12 @@ http.Handle("/", adapters.NetHTTPMiddleware(config)(myHandler))
 
 ```java
 // Spring
+ProducerConfig config = ProducerConfig.builder()
+    .schemaId("petstore")
+    .validator(validator)
+    .mode(ValidationMode.STRICT)
+    .build();
+
 registry.addInterceptor(new SpringInterceptor(config))
     .addPathPatterns("/api/**");
 ```

--- a/docs/guides/validation-modes.mdx
+++ b/docs/guides/validation-modes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Validation Modes
 sidebar_label: Validation Modes
-sidebar_position: 3
+sidebar_position: 4
 description: CVT producer middleware validation modes - strict, warn, and shadow
 ---
 
@@ -10,105 +10,35 @@ import TabItem from '@theme/TabItem';
 
 # Validation Modes
 
-## What are Validation Modes?
+When CVT middleware validates requests and responses in your running API server, **mode** decides what it does with violations: reject, log, or silently record. Three modes, picked to let you roll out contract enforcement without breaking clients.
 
-When you add CVT validation middleware to your API server, you need to decide what happens when a request or response doesn't match your OpenAPI schema. Should invalid requests be rejected? Should violations be logged? Or should validation run silently in the background?
+## TL;DR
 
-**Validation modes** control this behavior. They let you start with zero-risk observability and gradually move toward full contract enforcement as you gain confidence.
+| Mode | Request violation | Response violation | Use when |
+|---|---|---|---|
+| **shadow** | Silent, metrics only | Silent, metrics only | Day 1 — deploying middleware; zero risk |
+| **warn** | Log, continue | Log, continue | Once metrics look sane; debug real issues |
+| **strict** | Reject (400) | Log (too late to block) | Contract enforced; invalid requests blocked |
 
-Adding contract validation to a production API can be risky. You might discover that:
-- Your OpenAPI spec doesn't match your actual implementation
-- Some clients send requests that don't match the documented format
-- Edge cases in your responses weren't captured in the schema
+**Path**: deploy shadow → read metrics → fix issues → switch to warn → fix more → switch to strict.
 
-Validation modes let you deploy safely by starting in observation mode, fixing issues, then enabling enforcement—without breaking existing clients.
-
-## Mode Reference
-
-| Mode       | Request Violation                | Response Violation                | Metrics  | Use Case                                  |
-| ---------- | -------------------------------- | --------------------------------- | -------- | ----------------------------------------- |
-| **strict** | Reject with 400 Bad Request      | Log error (response already sent) | Recorded | Production enforcement after rollout      |
-| **warn**   | Log warning, continue processing | Log warning, continue             | Recorded | Gradual rollout, monitoring impact        |
-| **shadow** | Silent (no logging)              | Silent (no logging)               | Recorded | Initial deployment, metrics-only analysis |
-
-## Mode Behavior Details
-
-### Strict Mode
+## Rollout strategy
 
 ```text
-Request → Validate → Invalid? → Return 400 (handler never executes)
-                   → Valid?   → Execute handler → Validate response → Log if invalid
+┌──────────┐     ┌──────────┐     ┌──────────┐
+│  SHADOW  │ ──► │   WARN   │ ──► │  STRICT  │
+└──────────┘     └──────────┘     └──────────┘
+ Deploy +         Enable           Full
+ measure          logging          enforcement
 ```
 
-- **Request violations**: Immediately rejected with `400 Bad Request` and error details
-- **Response violations**: Logged as errors but response is still sent (can't unsend)
-- **Best for**: Production APIs after you've validated with warn/shadow modes
+1. **Deploy with `shadow`** — middleware on, zero behavioral change. Watch `cvt_validation_errors_total` in Grafana to establish a baseline.
+2. **Analyze metrics** — which endpoints violate most? Usually: missing required fields, wrong types, undocumented endpoints.
+3. **Switch to `warn`** — now you get detailed error logs for each violation. Review them.
+4. **Fix** — either update your OpenAPI spec to match reality, or fix server code to match the spec. This is where you decide what the contract actually is.
+5. **Switch to `strict`** — invalid requests get rejected with 400. Contract is enforced.
 
-### Warn Mode
-
-```text
-Request → Validate → Log if invalid → Execute handler → Validate response → Log if invalid
-```
-
-- **Request violations**: Logged as warnings, request continues to handler
-- **Response violations**: Logged as warnings, response is sent normally
-- **Best for**: Transitioning from shadow to strict, identifying issues without breaking clients
-
-### Shadow Mode
-
-```text
-Request → Validate → Execute handler → Validate response
-                ↓                              ↓
-          Record metrics                Record metrics
-           (no logging)                  (no logging)
-```
-
-- **Request violations**: Only recorded in metrics, no logs, no impact
-- **Response violations**: Only recorded in metrics, no logs, no impact
-- **Best for**: Initial deployment to measure contract compliance without any risk
-
-## Recommended Rollout Strategy
-
-```text
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                        Production Rollout Phases                             │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│   Phase 1               Phase 2               Phase 3                       │
-│   ┌──────────┐          ┌──────────┐          ┌──────────┐                  │
-│   │  SHADOW  │ ──────►  │   WARN   │ ──────►  │  STRICT  │                  │
-│   └──────────┘          └──────────┘          └──────────┘                  │
-│                                                                             │
-│   • Deploy middleware    • Enable logging     • Full enforcement            │
-│   • Monitor metrics      • Review violations  • Reject invalid requests     │
-│   • Zero risk            • Fix issues found   • Contract is enforced        │
-│   • Measure baseline     • No client impact   • Clients must comply         │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
-**Step-by-step:**
-
-1. **Deploy with `shadow`** — Add middleware to production with zero risk. Monitor the `cvt_validation_errors_total` metric to understand your baseline.
-
-2. **Analyze metrics** — Use Grafana dashboards to identify which endpoints have the most violations. Common issues: missing required fields, wrong types, undocumented endpoints.
-
-3. **Switch to `warn`** — Enable logging to get detailed error messages. Review logs to understand exactly what's failing and why.
-
-4. **Fix violations** — Either update your OpenAPI spec to match reality, or fix client/server code to match the spec. This is where you decide what the contract should be.
-
-5. **Switch to `strict`** — Full enforcement. Invalid requests are rejected. Your API contract is now enforced.
-
-## Mode Configuration by SDK
-
-Each SDK uses language-appropriate naming conventions:
-
-| SDK         | Strict                  | Warn                  | Shadow                  |
-| ----------- | ----------------------- | --------------------- | ----------------------- |
-| **Node.js** | `mode: "strict"`        | `mode: "warn"`        | `mode: "shadow"`        |
-| **Python**  | `ValidationMode.STRICT` | `ValidationMode.WARN` | `ValidationMode.SHADOW` |
-| **Go**      | `producer.ModeStrict`   | `producer.ModeWarn`   | `producer.ModeShadow`   |
-| **Java**    | `ValidationMode.STRICT` | `ValidationMode.WARN` | `ValidationMode.SHADOW` |
+## Configuring the mode
 
 <Tabs groupId="sdk-language">
   <TabItem value="nodejs" label="Node.js" default>
@@ -163,26 +93,47 @@ ProducerConfig config = ProducerConfig.builder()
   </TabItem>
 </Tabs>
 
-## Metrics Emitted
+<details>
+<summary>Full mode-by-mode behavior (request + response flow per mode)</summary>
 
-All modes emit Prometheus metrics for monitoring:
+**Strict mode**:
 
-| Metric                            | Description                                         |
-| --------------------------------- | --------------------------------------------------- |
-| `cvt_validations_total`           | Total validations by schema, method, result         |
-| `cvt_validation_errors_total`     | Validation failures by error category               |
-| `cvt_validation_duration_seconds` | Validation latency histogram by schema and method   |
+```text
+Request → Validate → Invalid? → Return 400 (handler never executes)
+                   → Valid?   → Execute handler → Validate response → Log if invalid
+```
 
-Use these metrics to:
+- Request violations rejected with `400 Bad Request` and error details.
+- Response violations logged as errors. The response is already on the wire — logging is all you can do.
+- Best for: production APIs after you've validated with warn/shadow first.
 
-- Track contract compliance over time
-- Identify problematic endpoints before enabling strict mode
-- Monitor the impact of API changes
-- Alert on sudden increases in validation failures
+**Warn mode**:
 
-## Response Validation Behavior
+```text
+Request → Validate → Log if invalid → Execute handler → Validate response → Log if invalid
+```
 
-**Important:** Response validation can only log, never block.
+- Request violations logged as warnings; request continues to your handler.
+- Response violations logged as warnings; response sent normally.
+- Best for: transitioning from shadow to strict — you see exactly what would break without breaking anyone.
+
+**Shadow mode**:
+
+```text
+Request → Validate → Execute handler → Validate response
+                ↓                              ↓
+          Record metrics                Record metrics
+           (no logging)                  (no logging)
+```
+
+- Request violations recorded in metrics only; no logs, no impact on the request.
+- Response violations recorded in metrics only; no logs, no impact.
+- Best for: Day 1 rollout — measure real contract compliance without any risk to clients.
+
+</details>
+
+<details>
+<summary>Why response validation can't block (physics of HTTP)</summary>
 
 ```text
 Client Request
@@ -200,14 +151,49 @@ Client Request
    Validate Response ─── Can only log (too late to block)
 ```
 
-This is by design: by the time we validate the response, it's already been sent to the client. Response validation helps you detect implementation drift (where your code diverges from your spec) but can't prevent invalid responses from reaching clients.
+By the time CVT validates your response, it's already on the wire. Response validation exists to detect implementation drift (your code diverging from your spec) — it can't prevent bad responses from reaching clients.
 
-**To prevent invalid responses:** Validate your response data before sending it, or use typed response builders that enforce the schema at compile time.
+**To actually prevent invalid responses**: validate response data in your handler before calling `res.send()` / equivalent, or use typed response builders that enforce schema at compile time.
+
+</details>
+
+<details>
+<summary>Metrics emitted (same for all modes)</summary>
+
+All modes emit Prometheus metrics; the only difference is mode-specific behavior around logging and request blocking.
+
+| Metric | Description |
+|---|---|
+| `cvt_validations_total` | Total validations by schema, method, result |
+| `cvt_validation_errors_total` | Validation failures by error category |
+| `cvt_validation_duration_seconds` | Validation latency histogram by schema and method |
+
+Use these to:
+- Track contract compliance over time.
+- Identify problematic endpoints before enabling strict mode.
+- Monitor the impact of API changes.
+- Alert on sudden increases in validation failures.
+
+See [Observability Guide](../operations/observability.md) for dashboards.
+
+</details>
+
+<details>
+<summary>Mode name reference (per SDK)</summary>
+
+| SDK | Strict | Warn | Shadow |
+|---|---|---|---|
+| **Node.js** | `mode: "strict"` | `mode: "warn"` | `mode: "shadow"` |
+| **Python** | `ValidationMode.STRICT` | `ValidationMode.WARN` | `ValidationMode.SHADOW` |
+| **Go** | `producer.ModeStrict` | `producer.ModeWarn` | `producer.ModeShadow` |
+| **Java** | `ValidationMode.STRICT` | `ValidationMode.WARN` | `ValidationMode.SHADOW` |
+
+</details>
 
 ---
 
-## Related Documentation
+## Related
 
-- **[Producer Testing Guide](./producer-testing.mdx)** - Full producer testing workflow
-- **[Observability Guide](../operations/observability.md)** - Metrics and monitoring
-- **[Configuration Reference](../reference/configuration.mdx)** - Environment variables
+- **[Producer Testing Guide](./producer-testing.mdx)** — full producer testing workflow (middleware is one approach among several).
+- **[Observability Guide](../operations/observability.md)** — reading the metrics this middleware emits.
+- **[Configuration Reference](../reference/configuration.mdx)** — server-side environment variables.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,156 +8,91 @@ slug: /intro
 
 # Welcome to CVT
 
-**Contract Validator Toolkit (CVT)** is a consumer- and producer-based contract validation platform for OpenAPI v2/v3 specifications.
+**CVT (Contract Validator Toolkit)** catches API breakage before it reaches production by validating HTTP traffic against the API's OpenAPI spec.
 
-It helps teams ensure their API consumers and producers communicate correctly by validating HTTP interactions against published contracts.
+## The problem (Alice, Bob, and last Tuesday)
 
-## What is Contract Testing?
+Alice's **checkout service** calls Bob's **Pets API** to show pet inventory at checkout.
 
-Contract testing validates API interactions against a published contract (OpenAPI specification). Unlike integration tests that require real services, contract tests verify that:
+Last Tuesday Bob renamed `status` to `availability` in the Pets API response. Alice's checkout crashed in production because her code still read `status`. Nobody noticed until orders started failing.
 
-- **Consumers** send valid requests and handle responses correctly
-- **Producers** return responses that match their published specification
+CVT would have caught the rename at PR time — before Bob's change ever merged.
 
-## Key Features
+## How CVT fixes it
 
-| Feature                       | Description                                                        |
-| ----------------------------- | ------------------------------------------------------------------ |
-| **Schema Validation**         | Register OpenAPI v2/v3 schemas and validate request/response pairs |
-| **Consumer Testing**          | Validate your HTTP calls against upstream API contracts            |
-| **Producer Testing**          | Ensure your API implementation matches your specification          |
-| **Breaking Change Detection** | Compare schema versions to detect incompatible changes             |
-| **Safe Deployments**          | Use CanIDeploy to verify changes won't break consumers             |
-| **Multi-language SDKs**       | Native support for Node.js, Python, Go, and Java                   |
+The fix is a two-sided handshake over the **OpenAPI spec** Bob already publishes.
 
-## Quick Start
+**Bob's side (the producer)**: Bob registers his OpenAPI spec with a shared CVT server as part of his CI. CVT knows exactly what his API promises to return.
 
-### 1. Start the CVT Server
+**Alice's side (the consumer)**: Alice's tests call CVT to validate every HTTP interaction her service makes against Bob's registered spec. When Alice's CI is green, she also registers with CVT to say "I depend on these endpoints and fields."
 
-```bash
-# Using the published Docker image (recommended)
-docker run -d -p 9550:9550 -p 9551:9551 ghcr.io/sahina/cvt:latest
-
-# Or using Docker Compose (if you've cloned the repository)
-make up
-
-# Or build and run locally
-make run-server
-```
-
-### 2. Install an SDK
-
-```bash
-# Node.js
-npm install @sahina/cvt-sdk
-
-# Python
-pip install cvt-sdk
-
-# Go
-go get github.com/sahina/cvt/sdks/go
-```
-
-For Java (Maven), add to `pom.xml`:
-
-```xml
-<dependency>
-    <groupId>io.github.sahina</groupId>
-    <artifactId>cvt-sdk</artifactId>
-    <version>0.1.3</version> <!-- Replace with latest from Maven Central -->
-</dependency>
-```
-
-See [Installation](./getting-started/installation.mdx) for detailed instructions.
-
-### 3. Validate an Interaction
-
-Save the [Petstore OpenAPI schema](https://petstore3.swagger.io/api/v3/openapi.json) as `./openapi.json`, then:
-
-```typescript
-import { ContractValidator } from "@sahina/cvt-sdk";
-
-const validator = new ContractValidator("localhost:9550");
-
-// Register your schema from file
-await validator.registerSchema("petstore", "./openapi.json");
-// Or register from URL:
-// await validator.registerSchema("petstore", "https://petstore3.swagger.io/api/v3/openapi.json");
-
-// Validate an interaction
-const result = await validator.validate(
-  { method: "GET", path: "/pet/123" },
-  {
-    statusCode: 200,
-    body: {
-      id: 123,
-      name: "doggie",
-      photoUrls: ["https://example.com/photo.jpg"],
-      status: "available",
-    },
-  },
-);
-
-console.log(result.valid); // true or false
-validator.close();
-```
-
-## Architecture
-
-CVT runs as a gRPC service that can be deployed via Docker or run locally:
+**The payoff**: before Bob merges a change, his CI runs `can-i-deploy`. CVT compares Bob's new spec against every registered consumer. Alice reads `status`? Bob renamed it? The deploy is blocked. The rename never ships.
 
 ```text
-┌─────────────────┐     gRPC      ┌─────────────────┐
-│   Your Tests    │ ────────────► │   CVT Server    │
-│  (SDK Client)   │               │   (Port 9550)   │
-└─────────────────┘               └─────────────────┘
-                                          │
-                                          ▼
-                                  ┌─────────────────┐
-                                  │ Schema Registry │
-                                  │  + Validation   │
-                                  └─────────────────┘
+      Alice's checkout                      Bob's Pets API
+       (consumer)                            (producer)
+            │                                    │
+            │ validate interactions              │ register schema
+            │ register as consumer               │ run can-i-deploy
+            ▼                                    ▼
+       ┌───────────────────────────────────────────────┐
+       │              CVT Server (shared)              │
+       │         Bob's schema = source of truth        │
+       │      Registry of Alice's dependencies         │
+       └───────────────────────────────────────────────┘
 ```
 
-:::tip Architecture Deep Dive
-For detailed system architecture, component design, validation engine, and storage layer documentation, see the [Architecture Documentation](./reference/architecture/index.md).
-:::
+## Contract testing in 30 seconds
 
-## Documentation Structure
+- **Contract** — the OpenAPI spec an API publishes. Machine-readable promise about paths, params, and response shapes.
+- **Producer** — the team that owns an API and its spec. Bob.
+- **Consumer** — a service that calls that API. Alice.
+- **Contract test** — a test that checks an actual HTTP interaction matches the contract.
+- **Breaking change** — a spec change that would make existing consumers fail (removed fields, new required fields, renamed keys, tightened types).
+- **`can-i-deploy`** — CVT's safety gate. Compares a new spec version against registered consumers and returns a verdict.
 
-### Getting Started
+## Pick your starting point
 
-- **[Installation](./getting-started/installation.mdx)** - Install the server and SDKs
-- **[Quick Start](./getting-started/quick-start.mdx)** - Your first contract test
+- **Consuming an API?** → [Quick Start](./getting-started/quick-start.mdx) — write your first consumer test in 5 minutes.
+- **Own an API?** → [Producer Testing Guide](./guides/producer-testing.mdx) — register your schema and verify your handlers match it.
+- **Wiring CI?** → [CanIDeploy](./guides/breaking-changes.mdx#deployment-safety-can-i-deploy) — the safety gate that ties both sides together.
 
-### Guides
+<details>
+<summary>New to OpenAPI? (1 minute)</summary>
 
-- **[Consumer Testing](./guides/consumer-testing.mdx)** - Test your API integrations
-- **[Producer Testing](./guides/producer-testing.mdx)** - Validate your APIs
-- **[Breaking Changes](./guides/breaking-changes.mdx)** - Detect schema incompatibilities
-- **[Validation Modes](./guides/validation-modes.mdx)** - Configure validation behavior
+OpenAPI is a machine-readable format for describing HTTP APIs — paths, methods, parameters, and response shapes. If your API has a Swagger UI page, there's an OpenAPI spec behind it. CVT accepts OpenAPI v3 natively and auto-converts Swagger 2.0.
 
-### Reference
+Learn more: [openapi.io](https://www.openapis.org/).
 
-- **[API Reference](./reference/api.mdx)** - gRPC API documentation
-- **[CLI Reference](./reference/cli.mdx)** - Command-line interface
-- **[Configuration](./reference/configuration.mdx)** - Environment variables
-- **[SDK Documentation](./reference/sdk/)** - Language-specific guides
+</details>
 
-### Operations
+<details>
+<summary>How is CVT different from Pact and other contract tools?</summary>
 
-- **[Observability](./operations/observability.md)** - Metrics, logging, and dashboards
+Pact is broker-centric and generates contracts from recorded interactions. CVT is **schema-first** — you bring an existing OpenAPI spec and validate against it directly. No broker to host, no contract generation step, no coordination between consumer and producer to author the contract.
 
-### Development
+If your team already maintains OpenAPI specs (most do), CVT uses them as the contract without an extra layer.
 
-- **[Contributing](./development/contributing.md)** - Local development setup
+</details>
 
-## Next Steps
+<details>
+<summary>Architecture deep dive</summary>
 
-Choose your path based on your role:
+For system architecture, component design, validation engine internals, and storage layer details, see the [Architecture Documentation](./reference/architecture/index.md).
 
-**API Consumer?** Start with the [Consumer Testing Guide](./guides/consumer-testing.mdx) to learn how to validate your API integrations.
+</details>
 
-**API Producer?** Check out the [Producer Testing Guide](./guides/producer-testing.mdx) to ensure your API matches its specification.
+## Install
 
-**Setting up CVT?** Follow the [Installation Guide](./getting-started/installation.mdx) for server setup and configuration.
+```bash
+# Server (Docker — recommended)
+docker run -d -p 9550:9550 -p 9551:9551 ghcr.io/sahina/cvt:latest
+
+# SDKs
+npm install @sahina/cvt-sdk        # Node.js
+pip install cvt-sdk                # Python
+go get github.com/sahina/cvt/sdks/go  # Go
+# Java — see Installation guide for Maven/Gradle
+```
+
+See the [Installation Guide](./getting-started/installation.mdx) for other install methods, verification, and Java setup.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -62,7 +62,7 @@ The fix is a two-sided handshake over the **OpenAPI spec** Bob already publishes
 
 OpenAPI is a machine-readable format for describing HTTP APIs — paths, methods, parameters, and response shapes. If your API has a Swagger UI page, there's an OpenAPI spec behind it. CVT accepts OpenAPI v3 natively and auto-converts Swagger 2.0.
 
-Learn more: [openapi.io](https://www.openapis.org/).
+Learn more: [openapis.org](https://www.openapis.org/).
 
 </details>
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -55,7 +55,7 @@ The fix is a two-sided handshake over the **OpenAPI spec** Bob already publishes
 
 - **Consuming an API?** → [Quick Start](./getting-started/quick-start.mdx) — write your first consumer test in 5 minutes.
 - **Own an API?** → [Producer Testing Guide](./guides/producer-testing.mdx) — register your schema and verify your handlers match it.
-- **Wiring CI?** → [CanIDeploy](./guides/breaking-changes.mdx#deployment-safety-can-i-deploy) — the safety gate that ties both sides together.
+- **Wiring CI?** → [CanIDeploy](./guides/can-i-deploy.mdx) — the safety gate that ties both sides together.
 
 <details>
 <summary>New to OpenAPI? (1 minute)</summary>

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,93 +1,100 @@
 # CVT Plugins
 
-CVT has a plugin system for teams that need to extend CVT without forking
-it. A plugin is a separate binary that implements one or more CVT plugin
-services (registry provider, event handler) and communicates with `cvt`
-over gRPC on a Unix domain socket. Plugins live in their own repositories
-on their own release schedules.
+CVT plugins extend the server without forking it. A plugin is a separate binary that implements one or more CVT plugin services (registry provider, event handler) and talks to `cvt` over gRPC via a Unix domain socket. Plugins live in their own repositories on their own release schedules.
 
-## Hook call-site status
+## TL;DR
 
-All four v1 hook call sites are wired today:
+```sh
+# 1. install a plugin binary
+cvt plugins install ./cvt-plugin-rest
 
-| Hook | Plugin service | Status |
+# 2. declare it in ~/.cvt/config.yaml
+cat > ~/.cvt/config.yaml <<'EOF'
+config_version: 1
+plugins:
+  registry:
+    binary: ~/.cvt/plugins/cvt-plugin-rest
+    on_error: fail_closed
+    secrets: [token]
+    config:
+      base_url: https://registry.example.com/api/v1
+      token: ${CVT_REGISTRY_TOKEN}
+hooks:
+  fetch_schema: registry
+  register_consumer_usage: registry
+EOF
+
+# 3. run CVT — plugin forks at startup and is ready for bound hooks
+cvt serve
+```
+
+`cvt plugins list` confirms the install; plugin logs show up in CVT's output with a `plugin=registry` field. Broken plugin? `CVT_DISABLE_PLUGINS=1 cvt serve` bypasses the plugin system entirely.
+
+## Pick your path
+
+- **Installing and running plugins?** Read [Config reference](config.md) and the [Reference plugins](reference-plugins.md) for turn-key installs.
+- **Writing a plugin?** [Authoring guide (Go)](authoring-go.md). Go is the only SDK in v1.
+- **Operating CVT with plugins in prod?** Trust model, metrics, and recovery are all covered below.
+
+## Hook status
+
+All four v1 hook call-sites are wired today. A plugin bound to any of them gets called from core.
+
+| Hook | Plugin service | Fires when |
 |---|---|---|
-| `on_validation_failed` | `EventHandler` | **wired** — fires from `pkg/cvt.Validator.Validate` after a non-valid result (CLI/library path) |
-| `on_breaking_change_detected` | `EventHandler` | **wired** — fires from `CompareSchemas` and from `RegisterSchema` when `--check-compatibility` is set |
-| `register_consumer_usage` | `RegistryProvider` | **wired** — fires from `RegisterConsumer` on success |
-| `fetch_schema` | `RegistryProvider` | **wired** — fires on schema cache miss, before storage fallback, for every RPC that resolves a schema by ID |
+| `fetch_schema` | `RegistryProvider` | Schema cache miss, before storage fallback, on every RPC that resolves a schema by ID |
+| `register_consumer_usage` | `RegistryProvider` | `RegisterConsumer` succeeds |
+| `on_breaking_change_detected` | `EventHandler` | `CompareSchemas` returns breaking changes, or `RegisterSchema --check-compatibility` detects them |
+| `on_validation_failed` | `EventHandler` | `pkg/cvt.Validator.Validate` returns a non-valid result (CLI/library path) |
 
-Plugins can be written, installed, and configured against all four hook
-names today. The SDK, proto contracts, and config schema are frozen.
+Plugins can be written, installed, and configured against all four hook names today. SDK, proto contracts, and config schema are frozen.
 
 ## When to use a plugin
 
-Use a plugin when you want:
+- **Custom schema registry.** Your org hosts OpenAPI specs in a registry with its own API (internal Central API Registry, Backstage, Apicurio). Write a `RegistryProvider` plugin and bind `fetch_schema` + `register_consumer_usage`. CVT's built-in loader only handles files and raw URLs; a bound plugin is authoritative.
+- **Event integrations.** Post breaking-change or validation-failure events to Slack, Jira, a webhook, your incident tool. Write an `EventHandler`.
 
-- **Custom schema registry.** CVT's built-in schema loading handles files
-  and raw URLs. If your organization hosts schemas in a registry with its
-  own API (internal Central API Registry, Backstage, Apicurio), write a
-  `RegistryProvider` plugin and point `fetch_schema` / `register_consumer_usage`
-  at it. `register_consumer_usage` fires on every `RegisterConsumer`;
-  `fetch_schema` fires on every schema cache miss before storage is
-  consulted, so a bound plugin is authoritative.
-- **Event integrations.** CVT fires events on breaking-change detection
-  and validation failure. Write an `EventHandler` plugin that reacts to
-  those events. Both `on_validation_failed` and `on_breaking_change_detected`
-  fire from core today.
+**Don't** write a plugin if you just want to patch CVT for your org — fork or vendor. Don't use a plugin to swap storage backends — that's in-tree in `server/storage/factory.go`.
 
-Don't write a plugin when:
+## Verifying your plugin is running
 
-- You just want to customize a single CVT build for your org — fork or
-  vendor instead.
-- You need to swap the storage backend — that's in-tree via
-  `server/storage/factory.go`, not a plugin.
+Four signals, any of which confirms the plugin is loaded and being called:
+
+```sh
+# 1. state.json knows about it
+cvt plugins list
+# NAME      SHA256        INSTALLED                  BINARY
+# registry  abc123def456  2026-04-20 12:35:00 EDT   /Users/you/.cvt/plugins/cvt-plugin-rest
+
+# 2. CVT logs show the plugin forked and handshake completed
+# (sample line — your log format may differ)
+# INFO plugin registered plugin=registry version=0.1.0 protocol_version=1 pid=12345
+
+# 3. /metrics exposes per-plugin counters
+curl -s http://localhost:9551/metrics | grep cvt_plugin_up
+# cvt_plugin_up{plugin="registry",version="0.1.0"} 1
+
+# 4. trigger the bound hook (e.g., `cvt validate --schema some-id`) and watch
+#    cvt_plugin_call_duration_seconds_count increment for your plugin
+curl -s http://localhost:9551/metrics | grep cvt_plugin_call_duration_seconds_count
+```
+
+Four plugin metrics are always emitted: `cvt_plugin_call_duration_seconds`, `cvt_plugin_call_errors_total`, `cvt_plugin_up`, `cvt_plugin_restarts_total`.
 
 ## Trust boundary
 
-**`cvt plugins install` is a privileged action.** Once installed, a plugin
-runs with the same permissions as the CVT process: it can read any file
-the user can, make any outbound network call, and use any environment
-variable. CVT does not sandbox plugins; it does not defend against
-malicious plugin code.
+**`cvt plugins install` is a privileged action.** A plugin runs with the same permissions as the CVT process: reads any file the user can, makes any outbound network call, sees any environment variable. CVT does not sandbox plugins.
 
-Treat plugin installation like installing any other binary on your
-system. Vet the source. Pin versions. Review SHA256 hashes against what
-the plugin author publishes.
+Treat plugin installation like installing any other binary on your system: vet the source, pin versions, verify SHA256 against what the author publishes. CVT records the install-time SHA256 in `~/.cvt/plugins/state.json`; `cvt plugins list` surfaces the first 12 chars so you can spot-check.
 
-## Quick tour
+## Recovering from a broken plugin
 
-1. **Install a plugin:**
-   ```sh
-   cvt plugins install ./cvt-plugin-rest
-   ```
-   The binary is copied into `~/.cvt/plugins/`; its SHA256 is recorded in
-   `~/.cvt/plugins/state.json`.
+1. `CVT_DISABLE_PLUGINS=1 cvt serve` — bring CVT back up, no plugins. Safe mode ignores `~/.cvt/config.yaml` entirely.
+2. Investigate via `cvt plugins list`, logs, and `/metrics`.
+3. `cvt plugins remove <name>` if the plugin should go (requires CVT not running).
+4. Fix config, restart CVT.
 
-2. **Declare the plugin in `~/.cvt/config.yaml`:**
-   ```yaml
-   config_version: 1
-   plugins:
-     registry:
-       binary: ~/.cvt/plugins/cvt-plugin-rest
-       on_error: fail_closed
-       secrets: [token]
-       config:
-         base_url: https://registry.example.com/api/v1
-         token: ${CVT_REGISTRY_TOKEN}
-   hooks:
-     fetch_schema: registry
-     register_consumer_usage: registry
-   ```
-
-3. **Run CVT.** The plugin forks at startup, receives its secret via
-   gRPC (not subprocess env), and is ready for the bound hooks. Three
-   of the four hooks fire from core today; see the status table above.
-   See [config.md](config.md) for the full schema.
-
-4. **Write your own plugin.** See [authoring-go.md](authoring-go.md).
-   Plugin authors import `github.com/sahina/cvt/pkg/cvtplugin` and call
-   `cvtplugin.Serve(...)` from their `main`. That's it.
+There is no hot reload in v1. Every config change requires a CVT restart.
 
 ## Architecture
 
@@ -97,52 +104,40 @@ the plugin author publishes.
     │  hashicorp/go-plugin: fork + gRPC over Unix socket
     ▼
   [cvt-plugin-rest]     [cvt-plugin-slack]
-       (subprocess)                  (subprocess)
+    (subprocess)          (subprocess)
 ```
 
-The plugin manager forks each configured plugin once at CVT startup,
-performs the native `go-plugin` handshake, calls the CVT-specific
-`PluginHandshake.Info` RPC to negotiate the protocol version, delivers
-configured values (including secrets) via `SetConfig`, and keeps the
-typed gRPC clients alive for the life of the CVT process. When CVT
-shuts down, plugins receive SIGTERM with a 30-second grace period, then
-SIGKILL.
+Plugin manager forks each configured plugin once at CVT startup, completes the `go-plugin` native handshake, calls `PluginHandshake.Info` to negotiate the protocol version, delivers configured values (secrets included) via `SetConfig`, and keeps the typed gRPC clients alive for the life of the CVT process. On shutdown: SIGTERM, 30-second grace, SIGKILL.
 
 ## Reference plugins
 
-Two first-party reference plugins ship in separate repos:
+Two first-party plugins ship in separate repos:
 
-- **[cvt-plugin-rest](https://github.com/sahina/cvt-plugin-rest)** —
-  `RegistryProvider` backed by any REST schema registry. Fetches
-  OpenAPI specs by ID and records consumer usage via HTTP. Covers
-  [issue #83](https://github.com/sahina/cvt/issues/83).
-- **[cvt-plugin-slack](https://github.com/sahina/cvt-plugin-slack)** —
-  `EventHandler` that posts breaking-change and validation-failure
-  events to a Slack webhook, with plugin-side dedup so you don't get
-  paged 10,000 times per bad deploy.
+- **[cvt-plugin-rest](https://github.com/sahina/cvt-plugin-rest)** — `RegistryProvider` backed by any REST schema registry. Covers [issue #83](https://github.com/sahina/cvt/issues/83).
+- **[cvt-plugin-slack](https://github.com/sahina/cvt-plugin-slack)** — `EventHandler` that posts breaking-change and validation-failure events to a Slack webhook, with plugin-side dedup.
 
-See [reference-plugins.md](reference-plugins.md) for walkthroughs and
-install recipes. Each plugin's own repo README covers its full config
-surface and a quick-test recipe.
+See [reference-plugins.md](reference-plugins.md) for decision table + walkthroughs.
 
-## Scope: what's in v1, what isn't
+## Scope
 
 **In v1:**
 - Two extension points: `RegistryProvider` and `EventHandler`.
 - One plugin per hook (no fanout).
-- Go SDK.
+- Go SDK only.
 - Linux + macOS.
-- Three CLI commands: `cvt plugins list`, `install`, `remove`.
-- Four Prometheus metrics + synchronous audit.
+- `cvt plugins {list, install, remove}`.
+- Four plugin metrics + synchronous audit.
 
-**Deferred to v1.1+:**
-- Multi-plugin fanout per hook, pipeline stages, `race`/`first_success`
-  strategies.
+<details>
+<summary>Deferred to v1.1+</summary>
+
+- Multi-plugin fanout per hook, pipeline stages, `race`/`first_success` strategies.
 - Custom `Validator` extension point.
-- Hot reload, circuit-breaker admin (`cvt plugins reset`), inspect/verify.
-- Python/Node/Java plugin SDKs.
+- Hot reload, circuit-breaker admin (`cvt plugins reset`), `cvt plugins inspect/verify`.
+- Python / Node / Java plugin SDKs.
 - Windows support.
 - GitHub-URL install, signed plugin tags.
 
-See the design doc at `docs/design/plugin-system.md` for the full scope
-reasoning.
+Full scope reasoning: [design/plugin-system.md](../design/plugin-system.md).
+
+</details>

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -71,15 +71,16 @@ cvt plugins list
 # INFO plugin registered plugin=registry version=0.1.0 protocol_version=1 pid=12345
 
 # 3. /metrics exposes per-plugin counters
-curl -s http://localhost:9551/metrics | grep cvt_plugin_up
-# cvt_plugin_up{plugin="registry",version="0.1.0"} 1
+curl -s http://localhost:9551/metrics | grep -E 'cvt_plugin_(up|info)'
+# cvt_plugin_up{plugin="registry"} 1
+# cvt_plugin_info{plugin="registry",version="0.1.0",sha256="abc123def456..."} 1
 
 # 4. trigger the bound hook (e.g., `cvt validate --schema some-id`) and watch
 #    cvt_plugin_call_duration_seconds_count increment for your plugin
 curl -s http://localhost:9551/metrics | grep cvt_plugin_call_duration_seconds_count
 ```
 
-Four plugin metrics are always emitted: `cvt_plugin_call_duration_seconds`, `cvt_plugin_call_errors_total`, `cvt_plugin_up`, `cvt_plugin_restarts_total`.
+Five plugin metrics are always emitted: `cvt_plugin_call_duration_seconds`, `cvt_plugin_call_errors_total`, `cvt_plugin_up`, `cvt_plugin_info`, `cvt_plugin_restarts_total`. `cvt_plugin_up` is labelled by plugin name only; `cvt_plugin_info` carries the version and SHA256 labels.
 
 ## Trust boundary
 
@@ -126,7 +127,7 @@ See [reference-plugins.md](reference-plugins.md) for decision table + walkthroug
 - Go SDK only.
 - Linux + macOS.
 - `cvt plugins {list, install, remove}`.
-- Four plugin metrics + synchronous audit.
+- Five plugin metrics + synchronous audit.
 
 <details>
 <summary>Deferred to v1.1+</summary>

--- a/docs/plugins/authoring-go.md
+++ b/docs/plugins/authoring-go.md
@@ -140,9 +140,9 @@ Plugins that ignore `ctx.Done()` eventually get killed by the supervisor, but th
 </details>
 
 <details>
-<summary>Connection pooling (reuse http.Client)</summary>
+<summary>Connection pooling (reuse one http.Client)</summary>
 
-Reuse a single `http.Client` across calls. The default client opens a new connection per request, which is wasteful when CVT sends many consecutive `FetchSchema` calls.
+Reuse a single `http.Client` across calls. Go's `http.DefaultClient` pools connections via HTTP/1.1 keep-alive / HTTP/2 multiplexing, but only if you reuse the same client — constructing a new `http.Client` or `http.Transport` per call throws away the pool and forces fresh connections. Store one `http.Client` on your plugin struct and reuse it.
 
 ```go
 type myRegistry struct {
@@ -153,6 +153,8 @@ func newRegistry() *myRegistry {
     return &myRegistry{hc: &http.Client{Timeout: 10 * time.Second}}
 }
 ```
+
+Also: fully drain and `Close()` response bodies so keep-alive connections actually return to the pool.
 
 </details>
 

--- a/docs/plugins/authoring-go.md
+++ b/docs/plugins/authoring-go.md
@@ -1,28 +1,12 @@
 # Writing a CVT plugin in Go
 
-A CVT plugin is a standalone Go binary. It implements one or both of the
-CVT plugin interfaces, calls `cvtplugin.Serve(...)` from its `main`, and
-`hashicorp/go-plugin` handles the subprocess lifecycle + gRPC transport
-for you.
+A CVT plugin is a standalone Go binary that implements one or both of the CVT plugin interfaces and calls `cvtplugin.Serve(...)` from its `main`. `hashicorp/go-plugin` handles subprocess lifecycle and gRPC transport.
 
-This guide walks through a minimal registry plugin. The same pattern
-applies to event handlers.
+Go is the only supported SDK in v1. Python / Node / Java are deferred to v1.1+.
 
-## 1. Start a new Go module
-
-```sh
-mkdir cvt-plugin-my-registry
-cd cvt-plugin-my-registry
-go mod init github.com/you/cvt-plugin-my-registry
-go get github.com/sahina/cvt/pkg/cvtplugin
-```
-
-## 2. Implement `RegistryProvider`
-
-Two methods. Both safe for concurrent use (CVT will send concurrent RPCs).
+## TL;DR — a minimum viable plugin in ~30 lines
 
 ```go
-// main.go
 package main
 
 import (
@@ -32,36 +16,51 @@ import (
     registrypb "github.com/sahina/cvt/pkg/cvtplugin/pb/registry/v1"
 )
 
-type myRegistry struct {
-    baseURL string
-    token   string
-}
+type myRegistry struct{}
 
 func (r *myRegistry) FetchSchema(ctx context.Context, req *registrypb.FetchSchemaRequest) (*registrypb.FetchSchemaResponse, error) {
-    // ... HTTP GET to r.baseURL ... respect ctx deadline ...
-    return &registrypb.FetchSchemaResponse{
-        Spec:            specBytes,
-        ResolvedVersion: "1.0.0",
-    }, nil
+    // fetch OpenAPI spec bytes by req.SchemaId / req.Version, respect ctx.Done()
+    return &registrypb.FetchSchemaResponse{Spec: specBytes, ResolvedVersion: "1.0.0"}, nil
 }
 
 func (r *myRegistry) RegisterConsumerUsage(ctx context.Context, req *registrypb.RegisterConsumerUsageRequest) (*registrypb.RegisterConsumerUsageResponse, error) {
-    // MUST be idempotent upsert. CVT provides at-most-one-plugin-per-hook
-    // semantics in v1, but your plugin's own dedup protects against
-    // retries, replays, and future v1.1 multi-sink fanout.
-    // ... HTTP POST to r.baseURL ...
+    // idempotent upsert
     return &registrypb.RegisterConsumerUsageResponse{Acknowledged: true}, nil
+}
+
+func main() {
+    cvtplugin.Serve(
+        cvtplugin.PluginInfo{Name: "my-registry", Version: "0.1.0"},
+        cvtplugin.WithRegistryProvider(&myRegistry{}),
+    )
 }
 ```
 
-## 3. Receive config via `SetConfig` (optional but recommended)
+Build it as `cvt-plugin-my-registry` (the `cvt-plugin-` prefix becomes the CVT-visible name), install with `cvt plugins install`, declare in `~/.cvt/config.yaml`, bind to hooks. Done.
 
-CVT delivers every `config:` entry from `~/.cvt/config.yaml` via a gRPC
-`SetConfig` call at plugin startup, before any extension-point RPC runs.
-Secret keys (declared in `secrets:`) are delivered this way too —
-**never** via subprocess environment variables.
+## Walkthrough
 
-Implement `cvtplugin.ConfigReceiver` to receive the calls:
+### 1. New Go module
+
+```sh
+mkdir cvt-plugin-my-registry && cd cvt-plugin-my-registry
+go mod init github.com/you/cvt-plugin-my-registry
+go get github.com/sahina/cvt/pkg/cvtplugin
+```
+
+### 2. Implement the interface
+
+`RegistryProvider` has two methods. Both must be safe for concurrent use — CVT sends concurrent RPCs. See TL;DR above for the full skeleton.
+
+Key contract:
+- `FetchSchema` — return raw OpenAPI bytes for `(SchemaId, Version)`. Respect `ctx.Done()` (see below).
+- `RegisterConsumerUsage` — **must be idempotent upsert** on your side. CVT guarantees at-most-one-plugin-per-hook in v1, but your dedup protects against retries, replays, and future v1.1 multi-sink fanout.
+
+### 3. Receive config
+
+CVT delivers every `config:` entry from `~/.cvt/config.yaml` via `SetConfig` gRPC at plugin startup, before any extension-point RPC runs. Secret keys are delivered this way too — **never** via subprocess env.
+
+Implement `cvtplugin.ConfigReceiver`:
 
 ```go
 func (r *myRegistry) SetConfig(_ context.Context, key, value string) error {
@@ -75,41 +74,28 @@ func (r *myRegistry) SetConfig(_ context.Context, key, value string) error {
 }
 ```
 
-Unknown keys should be accepted silently — CVT versions newer than your
-plugin may add keys your code doesn't know yet.
+Accept unknown keys silently — a future CVT may deliver keys your plugin doesn't know yet.
 
-## 4. Wire up `main`
+Register the receiver alongside the provider:
 
 ```go
-func main() {
-    r := &myRegistry{}
-    cvtplugin.Serve(
-        cvtplugin.PluginInfo{
-            Name:    "my-registry",
-            Version: "0.1.0",
-        },
-        cvtplugin.WithRegistryProvider(r),
-        cvtplugin.WithConfigReceiver(r),
-    )
-}
+cvtplugin.Serve(
+    cvtplugin.PluginInfo{Name: "my-registry", Version: "0.1.0"},
+    cvtplugin.WithRegistryProvider(r),
+    cvtplugin.WithConfigReceiver(r),
+)
 ```
 
-`Serve` blocks until CVT disconnects. Any return from `Serve` causes
-`go-plugin` to exit the process, which is the correct behavior on
-shutdown.
+### 4. Build with the expected name
 
-## 5. Build with the expected name
-
-CVT plugin names (the config-file key under `plugins:`) default to the
-binary basename with a `cvt-plugin-` prefix stripped. Install the binary
-as `cvt-plugin-my-registry` and it becomes the plugin named `my-registry`:
+Plugin name in config defaults to the binary basename with the `cvt-plugin-` prefix stripped. Build the binary as `cvt-plugin-my-registry` → CVT-visible name is `my-registry`:
 
 ```sh
 go build -o cvt-plugin-my-registry .
 cvt plugins install ./cvt-plugin-my-registry
 ```
 
-## 6. Add to `~/.cvt/config.yaml`
+### 5. Declare in config
 
 ```yaml
 config_version: 1
@@ -126,29 +112,20 @@ hooks:
   register_consumer_usage: my-registry
 ```
 
-Run CVT. Your plugin handles both hooks.
+Run CVT; your plugin handles both hooks. Verify with `cvt plugins list` + the `cvt_plugin_up{plugin="my-registry"}` metric on `:9551/metrics`.
 
-## Logging
+---
 
-`go-plugin` forwards structured logs from plugins to CVT's host logger.
-Use `hclog.Logger` (or just `log` — `go-plugin` intercepts standard
-library log output too):
+## Next
 
-```go
-import "github.com/hashicorp/go-hclog"
+- [Config reference](config.md) — full config.yaml schema.
+- [Reference plugins](reference-plugins.md) — walkthroughs of the two first-party plugins.
+- Proto contracts live at `api/protos/plugin/` in the CVT repo.
 
-logger := hclog.Default()
-logger.Info("fetched schema", "schema_id", id, "duration_ms", dur.Milliseconds())
-```
+<details>
+<summary>Respecting context deadlines (mandatory)</summary>
 
-Log entries arrive in CVT logs with a `plugin=<name>` field
-automatically added. No need to include the plugin name yourself.
-
-## Context deadlines
-
-Every plugin RPC runs under a context deadline derived from the
-plugin's `timeout` config (default 5s). Your handler MUST respect
-`ctx.Done()`:
+Every plugin RPC runs under a context deadline derived from the plugin's `timeout` config (default 5s). Your handler **must** respect `ctx.Done()`:
 
 ```go
 func (r *myRegistry) FetchSchema(ctx context.Context, req *registrypb.FetchSchemaRequest) (*registrypb.FetchSchemaResponse, error) {
@@ -158,14 +135,14 @@ func (r *myRegistry) FetchSchema(ctx context.Context, req *registrypb.FetchSchem
 }
 ```
 
-Plugins that ignore `ctx.Done()` eventually get killed by the supervisor,
-but they burn subprocess time in the meantime.
+Plugins that ignore `ctx.Done()` eventually get killed by the supervisor, but they burn subprocess time in the meantime.
 
-## Connection pooling
+</details>
 
-Reuse a single `http.Client` across calls. The default client opens a
-new connection per request, which is wasteful when CVT sends many
-consecutive `FetchSchema` calls.
+<details>
+<summary>Connection pooling (reuse http.Client)</summary>
+
+Reuse a single `http.Client` across calls. The default client opens a new connection per request, which is wasteful when CVT sends many consecutive `FetchSchema` calls.
 
 ```go
 type myRegistry struct {
@@ -177,10 +154,53 @@ func newRegistry() *myRegistry {
 }
 ```
 
-## Unit testing with `plugintest`
+</details>
 
-The SDK ships an in-process test harness so you can exercise your
-implementation without forking a subprocess:
+<details>
+<summary>Implementing only some event methods</summary>
+
+`EventHandler` has one RPC per event type. If you only care about some, embed `cvtplugin.UnimplementedEventHandler` — CVT treats `Unimplemented` as a non-error no-op.
+
+```go
+type mySlack struct {
+    cvtplugin.UnimplementedEventHandler
+}
+
+// Only implement the event you care about.
+func (s *mySlack) OnBreakingChangeDetected(ctx context.Context, req *eventspb.BreakingChangeDetectedRequest) (*eventspb.EventResponse, error) {
+    // post to Slack
+    return &eventspb.EventResponse{Acknowledged: true}, nil
+}
+```
+
+</details>
+
+<details>
+<summary>Logging</summary>
+
+`go-plugin` forwards structured logs from plugins to CVT's host logger. Use `hclog.Logger` (or stdlib `log` — `go-plugin` intercepts it):
+
+```go
+import "github.com/hashicorp/go-hclog"
+
+logger := hclog.Default()
+logger.Info("fetched schema", "schema_id", id, "duration_ms", dur.Milliseconds())
+```
+
+Entries arrive in CVT logs with a `plugin=<name>` field added automatically. Don't include the plugin name yourself.
+
+Sample log line on CVT's side:
+
+```text
+INFO plugin-log plugin=my-registry version=0.1.0 msg="fetched schema" schema_id=pet-api duration_ms=42
+```
+
+</details>
+
+<details>
+<summary>Unit testing with plugintest</summary>
+
+The SDK ships an in-process test harness — exercise your implementation without forking a subprocess:
 
 ```go
 import "github.com/sahina/cvt/pkg/cvtplugin/plugintest"
@@ -191,43 +211,17 @@ func TestFetchSchema(t *testing.T) {
     h.SetConfig(context.Background(), "base_url", "http://127.0.0.1:8080")
 
     resp, err := h.FetchSchema(context.Background(), &registrypb.FetchSchemaRequest{SchemaId: "pet-api"})
-    // ... assertions ...
+    // assertions...
 }
 ```
 
-## Implementing only part of an interface
+</details>
 
-`EventHandler` has multiple RPC methods (one per event type) but you may
-only care about some. Embed `cvtplugin.UnimplementedEventHandler` to
-auto-return `Unimplemented` for events you don't handle. CVT treats
-`Unimplemented` as a no-op, not an error.
+<details>
+<summary>Releasing</summary>
 
-```go
-type mySlack struct {
-    cvtplugin.UnimplementedEventHandler
-}
+- Ship SHA256 hashes alongside your binaries. `cvt plugins install` records the hash; operators should verify against your published hash. Hash is the trusted identity in CVT audit logs.
+- Tag releases against the proto version you're compatible with. Plugin proto bumps to `v2` would break `v1` plugins at handshake — reject cleanly.
+- Linux + macOS only in v1. Windows plugin support is v1.1+.
 
-// Implement only the event you care about.
-func (s *mySlack) OnBreakingChangeDetected(ctx context.Context, req *eventspb.BreakingChangeDetectedRequest) (*eventspb.EventResponse, error) {
-    // ... post to Slack ...
-    return &eventspb.EventResponse{Acknowledged: true}, nil
-}
-```
-
-## Releasing
-
-Ship SHA256 hashes alongside your binaries so operators can verify them
-against what `cvt plugins install` records. The install-time hash is the
-trusted identity in CVT audit logs.
-
-Tag releases against the proto version you're compatible with. Changes
-to the plugin proto bump to `v2`; plugins built against `v1` won't load
-in a core that expects `v2`.
-
-## Where to go next
-
-- [Config reference](config.md) — the full config.yaml schema.
-- [Reference plugins](reference-plugins.md) — walkthroughs of the two
-  first-party reference plugins.
-- Proto files live at `api/protos/plugin/` in the CVT repo — the wire
-  contract.
+</details>

--- a/docs/plugins/config.md
+++ b/docs/plugins/config.md
@@ -1,10 +1,8 @@
 # Plugin config
 
-CVT reads plugin configuration from a single YAML file at
-`~/.cvt/config.yaml`. If the file doesn't exist, the plugin system stays
-dormant (no plugins run, no overhead).
+CVT reads plugin configuration from a single YAML file at `~/.cvt/config.yaml`. If the file doesn't exist, the plugin system stays dormant — no plugins run, no overhead.
 
-## Minimal example
+## TL;DR — minimum viable config
 
 ```yaml
 config_version: 1
@@ -20,23 +18,45 @@ hooks:
   fetch_schema: registry
 ```
 
-Run CVT; the `registry` plugin forks at startup. All four hooks fire
-from core today — see the hook status table in `README.md`.
+This binds the `registry` plugin to `fetch_schema`. Run `cvt serve`; the plugin forks at startup, receives `base_url` and `token` via gRPC (not subprocess env), and handles every schema-by-ID resolution.
 
-## Full schema
+## Hook reference
+
+Four hook points. Each binds to at most one plugin; an unset hook falls back to CVT's built-in behavior.
+
+| Hook | Plugin service | Fires when | Status |
+|---|---|---|---|
+| `fetch_schema` | `RegistryProvider` | Schema-by-ID resolution, on cache miss, before storage fallback | **wired** |
+| `register_consumer_usage` | `RegistryProvider` | `RegisterConsumer` succeeds | **wired** |
+| `on_breaking_change_detected` | `EventHandler` | `CompareSchemas`, or `RegisterSchema` when `--check-compatibility` detects breaks | **wired** |
+| `on_validation_failed` | `EventHandler` | `ValidateInteraction` returns a non-valid result | **wired** |
+
+Binding a hook to a plugin that isn't declared under `plugins:` is a load-time error.
+
+## Recovering from a broken config
+
+```sh
+CVT_DISABLE_PLUGINS=1 cvt serve
+```
+
+Safe mode ignores `~/.cvt/config.yaml` entirely. Use it if a misconfigured plugin prevents CVT from starting. Then edit the config or `cvt plugins remove <name>` and restart.
+
+---
+
+<details>
+<summary>Full config schema</summary>
 
 ```yaml
-config_version: 1                # required; rejects unknown versions
+config_version: 1                # required; unknown versions rejected
 
 plugins:
   <name>:                         # name matches ^[a-z][a-z0-9-]{0,31}$
     binary: <path>                # required; must be under ~/.cvt/plugins/
     timeout: 5s                   # per-call gRPC deadline; default 5s
-    on_error: fail_closed         # fail_closed (default) or fail_open
-    secrets: [key1, key2]         # keys in config: that should be
-                                  # redacted and delivered via SetConfig
-    config:                       # free-form map delivered to the plugin
-      key: value                  # via SetConfig on startup
+    on_error: fail_closed         # fail_closed (default) | fail_open
+    secrets: [key1, key2]         # keys redacted + delivered via SetConfig
+    config:                       # free-form map, delivered via SetConfig
+      key: value
       token: ${ENV_VAR}           # ${VAR} interpolation
       base_url: ${OVERRIDE:-https://default.example.com}  # with default
 
@@ -47,117 +67,71 @@ hooks:
   on_validation_failed: <plugin-name>         # optional
 ```
 
-## Field reference
+</details>
+
+<details>
+<summary>Field reference</summary>
 
 ### `config_version`
 
-Schema version. CVT accepts `1` in this release. Unknown versions fail
-at load time with an upgrade hint. Bump only when the config shape
-changes incompatibly.
+Schema version. Current release accepts `1`. Unknown versions fail at load time with an upgrade hint. Bumps only on incompatible config-shape changes.
 
 ### `plugins.<name>`
 
-The map key is the plugin's CVT-visible name (not the plugin's
-self-reported name — that's recorded separately as `reported_version`).
-Plugin names must match `^[a-z][a-z0-9-]{0,31}$`: start with a lowercase
-letter, contain only lowercase letters, digits, and hyphens, 1 to 32
-chars. Invalid names are load-time errors.
+Map key = plugin's CVT-visible name (not the plugin's self-reported name, which is recorded separately as `reported_version`). Must match `^[a-z][a-z0-9-]{0,31}$`: lowercase letters, digits, hyphens, starting with a letter, 1–32 chars. Invalid name is a load-time error.
 
 ### `binary`
 
-Absolute path to the plugin binary. Must be under `~/.cvt/plugins/`. A
-leading `~/` is expanded. Any other location is rejected as a load-time
-error; this is the primary defense against a config file pointing at an
-arbitrary binary.
+Absolute path to the plugin binary. Must be under `~/.cvt/plugins/`; leading `~/` is expanded. Any other location is rejected — primary defense against a config pointing at an arbitrary binary.
 
 ### `timeout`
 
-Per-call gRPC deadline applied to every plugin RPC. Default `5s`.
-Plugin calls that exceed the deadline return `DeadlineExceeded`; the
-hook adapter applies `on_error` and records the call as `outcome=timeout`
-in audit.
+Per-call gRPC deadline for every plugin RPC. Default `5s`. Exceeded calls return `DeadlineExceeded`; the hook adapter applies `on_error` and records `outcome=timeout` in audit.
 
 ### `on_error`
 
-Either `fail_closed` (default) or `fail_open`.
-
-- `fail_closed`: plugin errors propagate to the caller. Use for plugins
-  the caller depends on (e.g., the primary schema registry).
-- `fail_open`: plugin errors are logged + audited but swallowed. Use for
-  truly-best-effort plugins (e.g., a Slack notifier — if Slack is down,
-  you don't want CI to fail).
+- `fail_closed` (default): plugin errors propagate to the caller. Use for plugins the caller depends on (a primary schema registry).
+- `fail_open`: plugin errors are logged and audited but swallowed. Use for best-effort sinks — a Slack notifier shouldn't fail CI.
 
 ### `secrets`
 
-List of keys in `config:` that should be treated as secret. Secret keys
-are:
+List of keys in `config:` treated as secret. Secret keys are:
 
-- Delivered to the plugin via the `SetConfig` gRPC call, NOT via
-  subprocess environment variables (env is readable from
-  `/proc/<pid>/environ`).
+- Delivered via `SetConfig` gRPC, **never** via subprocess env (env is readable from `/proc/<pid>/environ`).
 - Redacted from CVT logs and audit entries.
-- Required to have a value after env interpolation. A secret declared
-  in `secrets:` but missing from `config:` is a load-time error.
+- Required to have a value after env interpolation. A secret in `secrets:` missing from `config:` is a load-time error.
 
 ### `config`
 
-Free-form string-to-string map. CVT delivers every entry to the plugin
-via `SetConfig` at startup, before any extension-point RPC runs.
-Environment-variable interpolation (`${VAR}`, `${VAR:-default}`) applies
-to values. Unset `${VAR}` without a default fails load-time.
+Free-form string-to-string map, delivered to the plugin via `SetConfig` at startup, before any extension-point RPC runs. POSIX-style env interpolation applies (see below).
 
 ### `hooks`
 
-Maps each of the four v1 hook points to exactly one plugin name. An
-unset hook means CVT falls back to its built-in behavior (no plugin
-runs for that hook).
+Maps each hook name to a declared plugin. Unset hook = built-in CVT behavior. See the hook reference table above.
 
-| Hook | When it fires | Plugin service | Status |
-|---|---|---|---|
-| `on_validation_failed` | After `ValidateInteraction` returns a non-valid result | `EventHandler` | **wired** |
-| `on_breaking_change_detected` | After `CompareSchemas`, or after `RegisterSchema` when `check_compatibility=true` and breaking changes are detected | `EventHandler` | **wired** |
-| `register_consumer_usage` | After `RegisterConsumer` succeeds | `RegistryProvider` | **wired** |
-| `fetch_schema` | Before schema-by-ID resolution (on cache miss, before storage) | `RegistryProvider` | **wired** |
+</details>
 
-A hook referencing a plugin that isn't declared under `plugins:` is a
-load-time error.
+<details>
+<summary>Environment-variable interpolation</summary>
 
-## Environment variable interpolation
+Two POSIX-style forms, applied to `config:` values after YAML parse, before secret delivery:
 
-Values under `config:` support two POSIX-style expressions:
+- `${VAR}` — substitute `$VAR`. Unset `$VAR` = load-time error.
+- `${VAR:-default}` — substitute `$VAR`; use `default` if unset or empty.
 
-- `${VAR}` — substitute the value of `$VAR`. Unset = load-time error.
-- `${VAR:-default}` — substitute `$VAR`; if unset or empty, use `default`.
+Unterminated `${` is a load-time error. Nested expressions are not supported.
 
-Interpolation runs after YAML parse, before secret delivery. Nested
-expressions are not supported.
+</details>
 
-Unterminated `${` sequences are load-time errors.
+<details>
+<summary>Config precedence and per-project config</summary>
 
-## Safe mode
+v1 loads exactly one file: `~/.cvt/config.yaml`. There is no project-level override.
 
-Set `CVT_DISABLE_PLUGINS=1` in the environment and CVT behaves as if
-no plugins were configured, regardless of what the file says. Use this
-to recover from a broken plugin that prevents `cvt serve` from
-starting:
+If you need per-project config today, two workarounds:
+- Check the config into your repo and symlink at setup.
+- Use a wrapper that sets `HOME` to a project-specific directory before invoking `cvt`.
 
-```sh
-CVT_DISABLE_PLUGINS=1 cvt serve
-```
+Project overrides are tracked for v1.1+.
 
-## Config precedence
-
-v1 loads exactly one file: `~/.cvt/config.yaml`. There is no project-level
-override in this release. Teams that want per-project config check the
-file into their repo and symlink it at setup, or use a wrapper that
-points `HOME` at a project-specific directory.
-
-## Recovering from a stuck plugin
-
-1. `CVT_DISABLE_PLUGINS=1 cvt serve` — bring CVT back up without plugins.
-2. Investigate via `cvt plugins list`, logs, and `/metrics`.
-3. `cvt plugins remove <name>` if the plugin should go.
-4. Edit config; restart CVT.
-
-There is no live hot reload or admin IPC in v1. Restart is required for
-every config change.
+</details>

--- a/docs/plugins/reference-plugins.md
+++ b/docs/plugins/reference-plugins.md
@@ -10,7 +10,7 @@ Two first-party plugins live in separate repositories. Together they exercise th
 | Track consumer→schema usage in a central system | [`cvt-plugin-rest`](https://github.com/sahina/cvt-plugin-rest) | `RegistryProvider` |
 | Post breaking-change alerts to Slack | [`cvt-plugin-slack`](https://github.com/sahina/cvt-plugin-slack) | `EventHandler` |
 | Alert the on-call channel on validation failures | [`cvt-plugin-slack`](https://github.com/sahina/cvt-plugin-slack) | `EventHandler` |
-| Something else | Write your own — [authoring guide](authoring-go.md) |
+| Something else | Write your own — [authoring guide](authoring-go.md) | Custom |
 
 Both reference plugins were extracted from the main CVT repo on 2026-04-19 and track CVT releases via the `github.com/sahina/cvt` Go module dependency. Each plugin's own repo README carries its full config surface and a quick-test recipe.
 
@@ -86,7 +86,7 @@ The repo README has a toy Python HTTP server recipe that answers both endpoints 
 
 Posts CVT events to a Slack webhook. Without a plugin these events are logged and audited but nobody outside CVT notices.
 
-- `OnValidationFailed` → Slack message describing the failed interaction (method, path, schema ID, first validation error). Fires from `ValidateInteraction`. Plugin-side dedup so a misconfigured producer throwing 10k failures/minute doesn't page your channel 10k times.
+- `OnValidationFailed` → Slack message describing a failed validation (method, path, schema ID, first validation error). Fires from `pkg/cvt.Validator.Validate` when it returns a non-valid result (CLI `cvt validate` path and library callers). Note: the server's `ValidateInteraction` gRPC method runs validation directly via `openapi3filter` and does **not** call this hook in v1. Plugin-side dedup so a misconfigured producer throwing 10k failures/minute doesn't page your channel 10k times.
 - `OnBreakingChangeDetected` → Slack message listing each breaking change (kind, method, path). Fires from `CompareSchemas` and from `RegisterSchema --check-compatibility`.
 
 Designed **fail-open**: Slack outages should not block `cvt validate` or `cvt serve`.

--- a/docs/plugins/reference-plugins.md
+++ b/docs/plugins/reference-plugins.md
@@ -1,73 +1,48 @@
 # Reference plugins
 
-Two first-party plugins live in separate repositories. Together they
-validate the plugin SDK from two angles — a read-heavy registry backend
-and an event fan-out sink — and cover the two concrete use cases the
-plugin system was built for.
+Two first-party plugins live in separate repositories. Together they exercise the plugin SDK from two angles — a read-heavy registry backend and an event fan-out sink — and cover the two concrete use cases the plugin system was built for.
 
-| Plugin | Contract | Repo | Covers |
-|---|---|---|---|
-| [`cvt-plugin-rest`](https://github.com/sahina/cvt-plugin-rest) | `RegistryProvider` | <https://github.com/sahina/cvt-plugin-rest> | REST-backed schema registries (issue [#83](https://github.com/sahina/cvt/issues/83)) |
-| [`cvt-plugin-slack`](https://github.com/sahina/cvt-plugin-slack) | `EventHandler` | <https://github.com/sahina/cvt-plugin-slack> | Slack notifications for breaking changes + validation failures |
+## Which plugin do I need?
 
-Both were extracted from this monorepo on 2026-04-19 and track CVT
-releases via the `github.com/sahina/cvt` Go module dependency.
-Each plugin's own repo README carries the full config surface and a
-quick-test recipe; this page is the walkthrough.
+| You want to… | Plugin | Contract |
+|---|---|---|
+| Fetch OpenAPI specs from a REST schema registry (Apicurio, Backstage, internal API registry) | [`cvt-plugin-rest`](https://github.com/sahina/cvt-plugin-rest) | `RegistryProvider` |
+| Track consumer→schema usage in a central system | [`cvt-plugin-rest`](https://github.com/sahina/cvt-plugin-rest) | `RegistryProvider` |
+| Post breaking-change alerts to Slack | [`cvt-plugin-slack`](https://github.com/sahina/cvt-plugin-slack) | `EventHandler` |
+| Alert the on-call channel on validation failures | [`cvt-plugin-slack`](https://github.com/sahina/cvt-plugin-slack) | `EventHandler` |
+| Something else | Write your own — [authoring guide](authoring-go.md) |
 
-## Install
+Both reference plugins were extracted from the main CVT repo on 2026-04-19 and track CVT releases via the `github.com/sahina/cvt` Go module dependency. Each plugin's own repo README carries its full config surface and a quick-test recipe.
 
-Clone the plugin repo, build the binary, install with `cvt plugins install`:
+## Install (same for both)
 
-```bash
-git clone https://github.com/sahina/cvt-plugin-rest
+```sh
+git clone https://github.com/sahina/cvt-plugin-rest  # or cvt-plugin-slack
 cd cvt-plugin-rest
 go build -o cvt-plugin-rest .
 cvt plugins install ./cvt-plugin-rest
 ```
 
-To install the Slack event sink, repeat the same steps against its repo:
+`cvt plugins install` copies the binary to `~/.cvt/plugins/` and records its SHA256 in `~/.cvt/plugins/state.json`. Verify:
 
-```bash
-git clone https://github.com/sahina/cvt-plugin-slack
-cd cvt-plugin-slack
-go build -o cvt-plugin-slack .
-cvt plugins install ./cvt-plugin-slack
+```sh
+cvt plugins list
+# NAME      SHA256        INSTALLED                  BINARY
+# rest      abc123def456  2026-04-20 12:35:00 EDT   /Users/you/.cvt/plugins/cvt-plugin-rest
 ```
 
-`cvt plugins install` copies the binary to `~/.cvt/plugins/` and
-records its SHA256 in `~/.cvt/plugins/state.json`. Verify with
-`cvt plugins list`.
+---
 
 ## cvt-plugin-rest
 
-**Repo:** <https://github.com/sahina/cvt-plugin-rest> ([README](https://github.com/sahina/cvt-plugin-rest#readme))
-**Contract:** `RegistryProvider`
-**Hooks it serves:** `fetch_schema`, `register_consumer_usage`
+**Repo:** <https://github.com/sahina/cvt-plugin-rest> · **Contract:** `RegistryProvider` · **Hooks:** `fetch_schema`, `register_consumer_usage`
 
-### What it does
+Bridges CVT to a **Central API Registry** — a service that hosts OpenAPI specs with versioning, access control, and consumer tracking (Apicurio, Backstage, SwaggerHub, or a homegrown REST API).
 
-CVT's built-in schema loader handles files and raw URLs. Many
-organizations run a **Central API Registry** instead — a service that
-hosts OpenAPI specs with versioning, access control, and consumer
-tracking (Apicurio, Backstage, SwaggerHub, or a homegrown REST API).
-`cvt-plugin-rest` is the bridge.
+- `FetchSchema` → `GET {base_url}/schemas/{id}/versions/{version}/spec`. Respects `version = "latest"` and the optional `X-Schema-Version` response header that exposes the resolved version.
+- `RegisterConsumerUsage` → `POST {base_url}/schemas/{id}/consumers` with consumer identity, schema version, environment, and endpoints tested. Must be an idempotent upsert on the registry side.
 
-- `FetchSchema`: translates "give me schema X at version Y" into
-  `GET {base_url}/schemas/{id}/versions/{version}/spec` and returns
-  the raw OpenAPI bytes. Respects `version = "latest"` and the
-  optional `X-Schema-Version` response header that exposes the
-  resolved version.
-- `RegisterConsumerUsage`: translates consumer-usage reporting into
-  `POST {base_url}/schemas/{id}/consumers` with a JSON body containing
-  consumer identity, schema version, environment, and endpoints
-  tested. MUST be an idempotent upsert on the server side. Your
-  registry can use this feed to answer "who depends on this schema?",
-  gate deployments on consumer coverage, or build a contract map.
-
-Design goal: stay thin. No caching. No auth flows beyond an optional
-bearer token. One retry on 5xx, then surface the failure via gRPC
-status.
+Design: thin bridge. No caching. No auth flows beyond an optional bearer token. One retry on 5xx, then surface failure via gRPC status.
 
 ### Config
 
@@ -86,61 +61,35 @@ hooks:
   register_consumer_usage: registry
 ```
 
-| Config key | Required | Description |
+| Key | Required | Description |
 |---|---|---|
-| `base_url` | yes | Registry API base URL. |
-| `token` | no | Bearer token sent as `Authorization: Bearer <token>`. Declare in `secrets:` to keep it out of logs. |
+| `base_url` | yes | Registry API base URL |
+| `token` | no | Bearer token; declare in `secrets:` to keep out of logs |
 
 ### Failure modes
 
-- Registry unreachable → plugin returns gRPC `Unavailable`. With
-  `on_error: fail_closed`, `cvt validate` fails.
-- Schema not found → plugin returns gRPC `NotFound`. CVT treats as
-  schema-resolution failure.
-- Registry returns 5xx → retried once by the plugin's internal HTTP
-  client, then surfaced.
+| Situation | Result |
+|---|---|
+| Registry unreachable | gRPC `Unavailable`; with `fail_closed`, `cvt validate` fails |
+| Schema not found | gRPC `NotFound`; CVT treats as schema-resolution failure |
+| Registry 5xx | One retry inside the plugin, then surfaced |
 
-### When to use this
+### Test drive without a real registry
 
-- Your organization runs a Central API Registry with a REST API and
-  wants CVT to fetch schemas from there instead of files/URLs.
-- You want consumer-usage tracking in CI — every `cvt validate` in your
-  pipeline records a consumer→schema dependency.
+The repo README has a toy Python HTTP server recipe that answers both endpoints with a minimal spec — enough to prove the wiring works end-to-end. See <https://github.com/sahina/cvt-plugin-rest#quick-test-against-a-fake-registry>.
 
-### Test drive
-
-Don't have a real registry? The repo README has a toy Python HTTP
-server recipe that answers both endpoints with a minimal spec — enough
-to prove the wiring works end-to-end. See
-<https://github.com/sahina/cvt-plugin-rest#quick-test-against-a-fake-registry>.
+---
 
 ## cvt-plugin-slack
 
-**Repo:** <https://github.com/sahina/cvt-plugin-slack> ([README](https://github.com/sahina/cvt-plugin-slack#readme))
-**Contract:** `EventHandler`
-**Hooks it serves:** `on_breaking_change_detected`, `on_validation_failed`
+**Repo:** <https://github.com/sahina/cvt-plugin-slack> · **Contract:** `EventHandler` · **Hooks:** `on_breaking_change_detected`, `on_validation_failed`
 
-### What it does
+Posts CVT events to a Slack webhook. Without a plugin these events are logged and audited but nobody outside CVT notices.
 
-CVT fires two categories of event during its normal operation. Without
-a plugin they're logged and audited but nobody outside CVT notices.
-`cvt-plugin-slack` turns those events into Slack messages.
+- `OnValidationFailed` → Slack message describing the failed interaction (method, path, schema ID, first validation error). Fires from `ValidateInteraction`. Plugin-side dedup so a misconfigured producer throwing 10k failures/minute doesn't page your channel 10k times.
+- `OnBreakingChangeDetected` → Slack message listing each breaking change (kind, method, path). Fires from `CompareSchemas` and from `RegisterSchema --check-compatibility`.
 
-- `OnValidationFailed`: formats and posts a message describing the
-  failed interaction (method, path, schema ID, first validation
-  error). Fires from `ValidateInteraction` whenever a request/response
-  pair fails validation — in CI, from `cvt validate`, or in a running
-  `cvt serve`. Includes per-plugin dedup so a misconfigured producer
-  throwing 10k failures/minute doesn't page your channel 10k times.
-- `OnBreakingChangeDetected`: formats a Slack message listing each
-  breaking change (kind, method, path) and posts to the webhook.
-  Fires from two paths: the `CompareSchemas` gRPC method (diff-tool
-  / PR-comment-bot pattern) and from `RegisterSchema` when
-  `check_compatibility=true` (CLI: `cvt register-schema --check-compatibility`).
-
-**Fail-open by default.** Slack outages should not block `cvt validate`
-or `cvt serve`. Configure `on_error: fail_open` and transient Slack
-failures are audited but swallowed.
+Designed **fail-open**: Slack outages should not block `cvt validate` or `cvt serve`.
 
 ### Config
 
@@ -149,7 +98,7 @@ plugins:
   slack:
     binary: ~/.cvt/plugins/cvt-plugin-slack
     timeout: 3s
-    on_error: fail_open   # don't let Slack outages fail CVT
+    on_error: fail_open   # Slack outages shouldn't fail CVT
     secrets: [webhook_url]
     config:
       webhook_url: ${SLACK_WEBHOOK}
@@ -160,55 +109,39 @@ hooks:
   on_validation_failed: slack
 ```
 
-| Config key | Required | Description |
+| Key | Required | Description |
 |---|---|---|
-| `webhook_url` | yes | Slack incoming-webhook URL. Declare in `secrets:`. |
-| `channel` | no | Override channel (the webhook's default is used if unset). |
-| `dedup_window_seconds` | no | Plugin-side dedup window for repeated events. Default `"60"`. Set `"0"` to disable. |
+| `webhook_url` | yes | Slack incoming-webhook URL; declare in `secrets:` |
+| `channel` | no | Override channel; webhook default otherwise |
+| `dedup_window_seconds` | no | Plugin-side dedup. Default `"60"`; `"0"` disables |
 
 ### Failure modes
 
-- Slack API unreachable → plugin returns error; `on_error: fail_open`
-  swallows it. Event is audited but not re-sent.
-- Rate-limited by Slack (`429`) → plugin backs off, drops subsequent
-  events in the window. Counted in audit.
-
-### When to use this
-
-- Ops team wants real-time notification on breaking-change detection
-  in CI.
-- Validation failures in production should page the on-call channel.
+| Situation | Result |
+|---|---|
+| Slack API unreachable | Plugin returns error; `fail_open` swallows it. Event audited, not re-sent |
+| Slack rate-limit (429) | Plugin backs off, drops subsequent events in the window. Counted in audit |
 
 ### Test drive
 
-Slack incoming webhooks are free for personal workspaces. The repo
-README has a 5-minute setup + a `cvt compare` recipe that posts a real
-message to your channel. See
-<https://github.com/sahina/cvt-plugin-slack#quick-test-with-a-personal-webhook>.
+Slack incoming webhooks are free on personal workspaces. The repo README has a 5-minute setup + a `cvt compare` recipe that posts a real message to your channel: <https://github.com/sahina/cvt-plugin-slack#quick-test-with-a-personal-webhook>.
 
-No Slack? Swap `webhook_url` for a request-inspector URL
-(`https://webhook.site/`) to see the raw JSON payloads.
+No Slack account? Swap `webhook_url` for a request-inspector URL (`https://webhook.site/`) to see the raw JSON payloads.
+
+---
 
 ## Why these two
 
-The plugin system exists to unblock two pieces of work that had been
-deferred as "needs design" TODOs:
+The plugin system was built to unblock two deferred tracks:
 
-1. **Issue [#83](https://github.com/sahina/cvt/issues/83)** — consumer
-   testing with a central schema registry.
-2. **P2: Notification system design** — integrations without embedding
-   Slack/Jira/etc. logic in core.
+1. **Issue [#83](https://github.com/sahina/cvt/issues/83)** — consumer testing with a central schema registry.
+2. **Notification system design** (P2 TODO) — integrations without embedding Slack/Jira/etc. logic in core.
 
-Building both as out-of-tree plugins validates the framework from two
-independent angles: one read-heavy registry backend, one event fan-out
-sink. Further plugins (GitHub-backed registry, Jira notifier, etc.) can
-follow the same pattern.
+Building both as out-of-tree plugins validates the framework from two independent angles: one read-heavy registry backend, one event fan-out sink. Further plugins (GitHub-backed registry, Jira notifier) can follow the same pattern.
 
 ## Contributing a new reference plugin
 
-See [authoring-go.md](authoring-go.md) for the mechanics. If the plugin
-is broadly useful (not org-specific), propose it as a new repo under
-`github.com/sahina/` via a CVT issue. The bar is:
+Mechanics: [authoring-go.md](authoring-go.md). If the plugin is broadly useful (not org-specific), propose it as a new repo under `github.com/sahina/` via a CVT issue. Bar:
 
 1. Handles a concrete use case at least two teams have asked for.
 2. Ships SHA256 hashes alongside release artifacts.


### PR DESCRIPTION
## Summary
- Layered rewrite of getting-started + guides around a single persona (junior dev told to add contract tests): TL;DR visible, walkthrough H2s, `<details>` for depth, never tabs for consumer-vs-producer.
- New `docs/guides/can-i-deploy.mdx` hub page pulls scattered deploy-safety content from breaking-changes, producer-testing, and ci-cd-integration into one canonical place; sidebar + homepage card updated.
- Plugin docs pass: close real gaps (verification steps, `cvt plugins list` sample output, plugin metrics surfaced to users, safe-mode recovery promoted, "Go-only in v1" explicit, 30-line minimum-viable-plugin skeleton); fix a stale helper name in the design doc. All factual claims cross-checked against `pkg/cvt`, `server/cvtservice`, `internal/pluginmgr`, `cmd/cvt/plugins.go`.

17 files, net −1903 lines while adding content (can-i-deploy.mdx + verification sections); savings come from deduplicating quickstart content across the guides and collapsing edge cases into `<details>`. Docusaurus build is clean — no broken anchors, no MDX errors.

## Test plan
- [ ] Browse the rendered docs site locally (`npm run start` in `docs-site/`) and read intro → quick-start → consumer-testing → producer-testing → can-i-deploy top-to-bottom as persona C.
- [ ] Confirm all four `<details>` patterns render: intro (3 blocks), quick-start (4), guides (varies), plugins/authoring-go (6).
- [ ] Verify sidebar shows `CanIDeploy` between Producer Testing and Breaking Changes.
- [ ] Homepage "Safe Deployment Checks" card links to `/docs/guides/can-i-deploy`.
- [ ] Spot-check that claimed CLI output (`cvt plugins list` table) matches real output when run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive `can-i-deploy` deployment safety guide with workflow instructions and consumer registry integration.
  * Restructured installation and quick-start guides for improved clarity and streamlined onboarding.
  * Updated consumer testing, producer testing, and breaking-changes guides with simplified examples and clearer workflows.
  * Enhanced plugin documentation with decision tables, configuration reference, and troubleshooting sections.
  * Reorganized getting-started content and related guide links across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->