### PR TITLE
docs: clarify consumers can reuse producer-registered schemas

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -31,6 +31,15 @@ By default, extra fields pass validation. This is because OpenAPI's `additionalP
 
 Yes. CVT auto-converts Swagger 2.0 to OpenAPI 3.x at registration time. You don't need to convert your spec manually — just pass it to `registerSchema` as-is.
 
+## If the producer already registered the schema, do I need to register it again as a consumer?
+
+No. The schema registry is shared — there's no concept of "producer-owned" vs. "consumer-owned" schemas. Once any party has called `registerSchema` for a given `schemaId`, anyone else can validate against it by referencing the same ID. Two common flows:
+
+- **Producer registers first (typical in a mature setup)**: the producer's CI publishes the schema to CVT on each release. Consumers call `validate()` and `registerConsumer(...)` against the existing `schemaId` — they never call `registerSchema()` themselves.
+- **Consumer registers first (greenfield / producer not onboarded yet)**: the consumer registers the producer's OpenAPI spec they already have a copy of, then validates their own calls against it. When the producer later adopts CVT, they can take over publishing the schema; the consumer's registration keeps working.
+
+[`registerConsumer`](../guides/consumer-testing.mdx#consumer-registration) only takes a `schemaId` reference, not schema content — so joining an already-registered schema is the same one-call operation regardless of who originally registered it.
+
 ## Do I need to register the schema before every test run?
 
 `registerSchema` is idempotent — calling it with the same ID and content is a no-op. Most teams call it once in `beforeAll` or test setup. If you enable [persistent storage](../reference/configuration.mdx), schemas also survive server restarts, so re-registration on startup is fast (it just confirms the schema is already there).

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -33,12 +33,16 @@ Yes. CVT auto-converts Swagger 2.0 to OpenAPI 3.x at registration time. You don'
 
 ## If the producer already registered the schema, do I need to register it again as a consumer?
 
-No. The schema registry is shared — there's no concept of "producer-owned" vs. "consumer-owned" schemas. Once any party has called `registerSchema` for a given `schemaId`, anyone else can validate against it by referencing the same ID. Two common flows:
+It depends on what "register" means — and the distinction matters:
 
-- **Producer registers first (typical in a mature setup)**: the producer's CI publishes the schema to CVT on each release. Consumers call `validate()` and `registerConsumer(...)` against the existing `schemaId` — they never call `registerSchema()` themselves.
-- **Consumer registers first (greenfield / producer not onboarded yet)**: the consumer registers the producer's OpenAPI spec they already have a copy of, then validates their own calls against it. When the producer later adopts CVT, they can take over publishing the schema; the consumer's registration keeps working.
+- **Server-side `RegisterSchema` RPC**: the CVT server's schema registry is shared and keyed by `schemaId`. Ownership metadata (`SchemaOwnership`: `owner`, `team`, `contact_email`, `read_only`) can be attached for documentation and audit, but validation logic does not enforce access control based on it — any party can validate against or register dependencies on any schema. `RegisterSchema` is idempotent: calling it with the same ID and content is a no-op.
+- **SDK `registerSchema(id, path)` call**: the SDK client still requires this on each validator instance to bind `schemaId` for subsequent `validate()` calls. Skipping it throws "Schema not registered." So consumers still call `registerSchema` locally — just idempotently, alongside whoever else registered it.
+- **SDK `registerConsumer({ schemaId, ... })`**: only references an existing `schemaId`; no schema content is transmitted. This is the step where "no re-registration" literally applies.
 
-[`registerConsumer`](../guides/consumer-testing.mdx#consumer-registration) only takes a `schemaId` reference, not schema content — so joining an already-registered schema is the same one-call operation regardless of who originally registered it.
+Two onboarding flows that both work:
+
+- **Producer registers first (typical mature setup)**: the producer's CI publishes the schema on each release. Consumers still call `registerSchema` on their validator instance (harmless idempotent sync) plus `registerConsumer(...)` to declare their dependency.
+- **Consumer registers first (greenfield / producer not onboarded)**: the consumer registers the producer's OpenAPI spec they already have a copy of, then validates their calls. When the producer later adopts CVT, their registration converges with the existing record.
 
 ## Do I need to register the schema before every test run?
 

--- a/docs/guides/can-i-deploy.mdx
+++ b/docs/guides/can-i-deploy.mdx
@@ -76,6 +76,10 @@ await validator.registerConsumer({
 
 Full walkthrough: [Consumer Testing → Consumer Registration](./consumer-testing.mdx#consumer-registration).
 
+:::info Who registers the schema itself?
+Either side. `registerConsumer` only references an existing `schemaId` — it doesn't take schema content. If the producer's CI already calls `registerSchema` on each release (the typical mature setup), consumers just reference that `schemaId` and don't register the schema themselves. If the producer hasn't onboarded yet, a consumer can register the schema once and everyone (including `can-i-deploy`) uses it. See the [FAQ entry on producer-already-registered schemas](../getting-started/faq.md#if-the-producer-already-registered-the-schema-do-i-need-to-register-it-again-as-a-consumer).
+:::
+
 :::info No consumers registered yet?
 `can-i-deploy` returns *safe* when no consumers are registered for the schema in that environment — there's nothing to break. This is expected on day one; it becomes load-bearing once consumers start registering. See the [no-consumers troubleshooting](#no-consumers-registered) note below.
 :::

--- a/docs/guides/can-i-deploy.mdx
+++ b/docs/guides/can-i-deploy.mdx
@@ -77,7 +77,7 @@ await validator.registerConsumer({
 Full walkthrough: [Consumer Testing → Consumer Registration](./consumer-testing.mdx#consumer-registration).
 
 :::info Who registers the schema itself?
-Either side. `registerConsumer` only references an existing `schemaId` — it doesn't take schema content. If the producer's CI already calls `registerSchema` on each release (the typical mature setup), consumers just reference that `schemaId` and don't register the schema themselves. If the producer hasn't onboarded yet, a consumer can register the schema once and everyone (including `can-i-deploy`) uses it. See the [FAQ entry on producer-already-registered schemas](../getting-started/faq.md#if-the-producer-already-registered-the-schema-do-i-need-to-register-it-again-as-a-consumer).
+`registerConsumer` only references an existing `schemaId` — it doesn't carry schema content, so it's the same call regardless of who first published the schema. The server-side schema registry is shared; ownership metadata exists but doesn't gate access. Note that the SDK's `registerSchema()` is still required on each validator instance to bind the `schemaId` for `validate()` — it's just idempotent server-side when the producer has already registered the same content. See the [FAQ entry on producer-already-registered schemas](../getting-started/faq.md#if-the-producer-already-registered-the-schema-do-i-need-to-register-it-again-as-a-consumer).
 :::
 
 :::info No consumers registered yet?

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -22,7 +22,12 @@ This guide covers the three validation approaches and consumer registration (the
 | **HTTP adapter** | Wrap your HTTP client; every call is validated automatically | Yes | Retrofitting existing integration tests |
 | **Mock adapter** | CVT generates spec-compliant responses in-process; no real call | No | CI without upstream services; unit tests |
 
-All three require the producer's schema to be registered with CVT. In production workflows the producer's CI does that; for local dev you can register it yourself with `validator.registerSchema(...)`.
+All three require the producer's schema to be registered with CVT — by *someone*, not necessarily you. There is no "producer-owned" vs. "consumer-owned" schema in CVT; the registry is shared.
+
+- **If the producer already registered the schema** (the common case in a mature setup), skip `registerSchema` entirely. Reference the existing `schemaId` in `validate()` and `registerConsumer()`.
+- **If no one has registered it yet** (greenfield, or producer hasn't adopted CVT), register it yourself with `validator.registerSchema(...)`. Your registration serves both sides until the producer takes over.
+
+`registerSchema` is idempotent, so it's safe to call unconditionally in local dev without worrying about duplicating the producer's registration.
 
 ---
 

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -22,12 +22,15 @@ This guide covers the three validation approaches and consumer registration (the
 | **HTTP adapter** | Wrap your HTTP client; every call is validated automatically | Yes | Retrofitting existing integration tests |
 | **Mock adapter** | CVT generates spec-compliant responses in-process; no real call | No | CI without upstream services; unit tests |
 
-All three require the producer's schema to be registered with CVT — by *someone*, not necessarily you. There is no "producer-owned" vs. "consumer-owned" schema in CVT; the registry is shared.
+All three require the producer's schema to be registered with CVT. The server-side registry is shared and keyed by `schemaId` — ownership metadata (`owner`, `team`, `contact_email`) can be attached, but validation doesn't gate on it, so there's no "producer-owned" vs. "consumer-owned" access distinction.
 
-- **If the producer already registered the schema** (the common case in a mature setup), skip `registerSchema` entirely. Reference the existing `schemaId` in `validate()` and `registerConsumer()`.
-- **If no one has registered it yet** (greenfield, or producer hasn't adopted CVT), register it yourself with `validator.registerSchema(...)`. Your registration serves both sides until the producer takes over.
+What that means for your SDK code:
 
-`registerSchema` is idempotent, so it's safe to call unconditionally in local dev without worrying about duplicating the producer's registration.
+- The SDK's `registerSchema(id, path)` is still required on each validator instance — `validate()` throws "Schema not registered" without it. Call it in `beforeAll` / test setup as usual.
+- `registerSchema` is idempotent server-side: calling it with the same `schemaId` and content when the producer already registered it is a harmless no-op.
+- `registerConsumer(...)` is the step that genuinely doesn't duplicate the producer's work — it only sends a `schemaId` reference, no schema content.
+
+So in practice: register the schema locally (whether you're the first to do it or not), validate, then call `registerConsumer` to declare your dependency. The producer's CI doing the same doesn't conflict with you.
 
 ---
 

--- a/docs/reference/architecture/consumer-registry.md
+++ b/docs/reference/architecture/consumer-registry.md
@@ -18,6 +18,24 @@ The consumer registry enables:
 3. **Breaking change detection**: Identify incompatible schema changes
 4. **Deployment safety**: Prevent breaking changes from reaching production
 
+## Schema Ownership Model
+
+CVT's schema registry is **shared, not role-partitioned**. A schema is identified by its `schemaId` alone — there is no `registeredBy` field, no producer-vs-consumer role flag, and no ownership check in `ValidateInteraction` or `CanIDeploy`. This produces two symmetrical onboarding flows:
+
+**Flow A — Producer registers first (typical mature setup)**
+
+1. Producer's CI publishes the OpenAPI spec via `RegisterSchema` on each release.
+2. Consumer's test suite calls `ValidateInteraction` and `RegisterConsumer` referencing the existing `schemaId`. The consumer never calls `RegisterSchema`.
+3. `CanIDeploy` runs on the producer's next release and sees the consumer's registered dependency.
+
+**Flow B — Consumer registers first (greenfield / producer not onboarded)**
+
+1. Consumer obtains the producer's OpenAPI spec (from source, a portal, etc.) and calls `RegisterSchema` itself.
+2. Consumer calls `ValidateInteraction` and `RegisterConsumer` against the schema it just registered.
+3. When the producer later adopts CVT, they register the next schema version. The consumer's registration — keyed by `schemaId`, not by who registered the schema — keeps working across versions.
+
+`RegisterConsumer` never accepts schema content; it only references an existing `schemaId`. Both flows therefore converge on the same consumer-registry state.
+
 ## Consumer Registration Flow
 
 ```mermaid

--- a/docs/reference/architecture/consumer-registry.md
+++ b/docs/reference/architecture/consumer-registry.md
@@ -20,21 +20,27 @@ The consumer registry enables:
 
 ## Schema Ownership Model
 
-CVT's schema registry is **shared, not role-partitioned**. A schema is identified by its `schemaId` alone — there is no `registeredBy` field, no producer-vs-consumer role flag, and no ownership check in `ValidateInteraction` or `CanIDeploy`. This produces two symmetrical onboarding flows:
+CVT's schema registry **keys schemas solely by `schemaId`**. The `SchemaOwnership` struct (`owner`, `team`, `contact_email`, `read_only`) is stored on `SchemaMetadata` and available for audit and display, but validation and deployment logic (`ValidateInteraction`, `CanIDeploy`, `RegisterConsumer`) do not enforce access control based on it. Any party can validate against, register a dependency on, or re-register any schema.
+
+:::note `read_only` is currently advisory
+The proto defines `SchemaOwnership.read_only` as "If true, schema cannot be updated," but no code path in `RegisterSchema` or the storage layer enforces this today. It should be treated as metadata-only until enforcement lands. Tracked as a follow-up defect.
+:::
+
+This produces two symmetrical onboarding flows:
 
 **Flow A — Producer registers first (typical mature setup)**
 
 1. Producer's CI publishes the OpenAPI spec via `RegisterSchema` on each release.
-2. Consumer's test suite calls `ValidateInteraction` and `RegisterConsumer` referencing the existing `schemaId`. The consumer never calls `RegisterSchema`.
+2. Consumer's test suite calls `RegisterSchema` on its SDK validator instance (required to bind `schemaId`; idempotent server-side when content matches), then `ValidateInteraction` and `RegisterConsumer` referencing the same `schemaId`.
 3. `CanIDeploy` runs on the producer's next release and sees the consumer's registered dependency.
 
 **Flow B — Consumer registers first (greenfield / producer not onboarded)**
 
-1. Consumer obtains the producer's OpenAPI spec (from source, a portal, etc.) and calls `RegisterSchema` itself.
+1. Consumer obtains the producer's OpenAPI spec and calls `RegisterSchema` itself.
 2. Consumer calls `ValidateInteraction` and `RegisterConsumer` against the schema it just registered.
-3. When the producer later adopts CVT, they register the next schema version. The consumer's registration — keyed by `schemaId`, not by who registered the schema — keeps working across versions.
+3. When the producer later adopts CVT, they register the next schema version. The consumer's registration — associated with the `schemaId`, not the registrant — keeps working across versions.
 
-`RegisterConsumer` never accepts schema content; it only references an existing `schemaId`. Both flows therefore converge on the same consumer-registry state.
+Only the `RegisterConsumer` call differs in shape: it takes just a `schemaId` reference (no schema content), so it is the one step that never duplicates work regardless of who registered the schema. Both flows converge on the same consumer-registry state, keyed by the `{consumerID, schemaID, environment}` tuple described below.
 
 ## Consumer Registration Flow
 


### PR DESCRIPTION
## Summary

Documents the (already-supported) flow where a consumer joins a schema the producer has already registered — no re-registration required. CVT's registry is shared; `schemaId` is the only key and `RegisterConsumer` takes a reference, not schema content.

Updates four docs:
- **FAQ** — new entry answering "do I need to register the schema if the producer already did?"
- **Consumer Testing Guide** — replaces the vague "producer's CI does it" line with the two concrete flows.
- **CanIDeploy Guide** — adds a callout next to consumer registration clarifying either side can register the schema.
- **Consumer Registry architecture doc** — new "Schema Ownership Model" section documenting Flow A (producer-first) and Flow B (consumer-first).

## Test plan
- [ ] Docusaurus build succeeds (`cd docs-site && npm run build`)
- [ ] New FAQ anchor link from can-i-deploy.mdx resolves
- [ ] Manual read-through for flow/clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify schema registration semantics, including that the schema registry is shared across producers and consumers with no ownership model distinctions.
  * Added guidance on two supported registration workflows (producer-first and consumer-first) and clarified that `registerConsumer` references an existing schema ID rather than registering schema content.
  * Noted that schema registration is idempotent for safer local development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->