### PR TITLE
feat(sdks): add useSchema() — skip local file when schema is server-registered (#120)

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -33,16 +33,25 @@ Yes. CVT auto-converts Swagger 2.0 to OpenAPI 3.x at registration time. You don'
 
 ## If the producer already registered the schema, do I need to register it again as a consumer?
 
-It depends on what "register" means — and the distinction matters:
+**No — use `useSchema(id)` instead of `registerSchema(id, path)`.** The distinction matters:
 
-- **Server-side `RegisterSchema` RPC**: the CVT server's schema registry is shared and keyed by `schemaId`. Ownership metadata (`SchemaOwnership`: `owner`, `team`, `contact_email`, `read_only`) can be attached for documentation and audit, but validation logic does not enforce access control based on it — any party can validate against or register dependencies on any schema. `RegisterSchema` is idempotent: calling it with the same ID and content is a no-op.
-- **SDK `registerSchema(id, path)` call**: the SDK client still requires this on each validator instance to bind `schemaId` for subsequent `validate()` calls. Skipping it throws "Schema not registered." So consumers still call `registerSchema` locally — just idempotently, alongside whoever else registered it.
-- **SDK `registerConsumer({ schemaId, ... })`**: only references an existing `schemaId`; no schema content is transmitted. This is the step where "no re-registration" literally applies.
+- **Server-side `RegisterSchema` RPC** is idempotent and the server's schema registry is shared, keyed by `schemaId`. Ownership metadata (`SchemaOwnership`: `owner`, `team`, `contact_email`, `read_only`) is for documentation and audit; validation logic does not enforce access control. Any party can validate against or register dependencies on any schema.
+- **SDK `useSchema(id)`** (recommended for consumers joining an existing registration): calls the server's `GetSchema` RPC to resolve the schema by ID, pins the validator to the concrete version the server returned, and requires **no local OpenAPI file**. Subsequent `validate()` calls are locked to that version.
+- **SDK `registerSchema(id, path)`** (for publishing/greenfield): reads a local OpenAPI file and publishes it to the server. Use this when **you are the producer** or when you're on the consumer-first path and the producer has not onboarded yet.
+- **SDK `registerConsumer({ schemaId, ... })`**: only references an existing `schemaId`; no schema content is transmitted. Declares your dependency once the validator is bound.
 
-Two onboarding flows that both work:
+Two onboarding flows:
 
-- **Producer registers first (typical mature setup)**: the producer's CI publishes the schema on each release. Consumers still call `registerSchema` on their validator instance (harmless idempotent sync) plus `registerConsumer(...)` to declare their dependency.
-- **Consumer registers first (greenfield / producer not onboarded)**: the consumer registers the producer's OpenAPI spec they already have a copy of, then validates their calls. When the producer later adopts CVT, their registration converges with the existing record.
+- **Producer registers first (typical mature setup) — Flow A**: consumers call `useSchema(id)` (no local file) + `registerConsumer(...)`. The producer's CI publishes the schema on each release; consumers just join.
+- **Consumer registers first (greenfield / producer not onboarded) — Flow B**: the consumer calls `registerSchema(id, path)` with a local copy of the producer's OpenAPI spec, then validates. When the producer later adopts CVT, their registration converges with the existing record.
+
+```ts
+// Flow A — consumer joins an existing registration (no file needed)
+const validator = new ContractValidator("localhost:9550");
+const info = await validator.useSchema("petstore");
+console.log(`Bound to ${info.schemaId}@${info.schemaVersion}`);
+await validator.validate(req, resp);
+```
 
 ## Do I need to register the schema before every test run?
 

--- a/docs/guides/can-i-deploy.mdx
+++ b/docs/guides/can-i-deploy.mdx
@@ -77,7 +77,14 @@ await validator.registerConsumer({
 Full walkthrough: [Consumer Testing → Consumer Registration](./consumer-testing.mdx#consumer-registration).
 
 :::info Who registers the schema itself?
-`registerConsumer` only references an existing `schemaId` — it doesn't carry schema content, so it's the same call regardless of who first published the schema. The server-side schema registry is shared; ownership metadata exists but doesn't gate access. Note that the SDK's `registerSchema()` is still required on each validator instance to bind the `schemaId` for `validate()` — it's just idempotent server-side when the producer has already registered the same content. See the [FAQ entry on producer-already-registered schemas](../getting-started/faq.md#if-the-producer-already-registered-the-schema-do-i-need-to-register-it-again-as-a-consumer).
+`registerConsumer` only references an existing `schemaId` — it doesn't carry schema content, so it's the same call regardless of who first published the schema. The server-side schema registry is shared; ownership metadata exists but doesn't gate access.
+
+On the SDK side, the validator still needs to know which `schemaId` to bind — but there are two paths:
+
+- **Producer already registered (Flow A, recommended default):** call `useSchema(id)` on your validator. Resolves the schema server-side and binds without a local OpenAPI file.
+- **Greenfield / consumer-first (Flow B):** call `registerSchema(id, path)` with a local copy of the spec. Idempotent server-side when the producer later adopts CVT.
+
+See the [FAQ entry on producer-already-registered schemas](../getting-started/faq.md#if-the-producer-already-registered-the-schema-do-i-need-to-register-it-again-as-a-consumer).
 :::
 
 :::info No consumers registered yet?

--- a/docs/guides/consumer-testing.mdx
+++ b/docs/guides/consumer-testing.mdx
@@ -24,13 +24,13 @@ This guide covers the three validation approaches and consumer registration (the
 
 All three require the producer's schema to be registered with CVT. The server-side registry is shared and keyed by `schemaId` — ownership metadata (`owner`, `team`, `contact_email`) can be attached, but validation doesn't gate on it, so there's no "producer-owned" vs. "consumer-owned" access distinction.
 
-What that means for your SDK code:
+What that means for your SDK code — two patterns:
 
-- The SDK's `registerSchema(id, path)` is still required on each validator instance — `validate()` throws "Schema not registered" without it. Call it in `beforeAll` / test setup as usual.
-- `registerSchema` is idempotent server-side: calling it with the same `schemaId` and content when the producer already registered it is a harmless no-op.
-- `registerConsumer(...)` is the step that genuinely doesn't duplicate the producer's work — it only sends a `schemaId` reference, no schema content.
+- **If the producer has already registered the schema (Flow A, recommended default for consumers):** use `useSchema(id)` on your validator. It resolves the schema by `schemaId` via `GetSchema`, pins the validator to the concrete version the server returned, and requires **no local OpenAPI file**. Optionally pass a version (`useSchema(id, version)`) to pin to a specific historical version.
+- **If you're the first to onboard the schema (Flow B, greenfield):** use `registerSchema(id, path)` with a local copy of the producer's OpenAPI spec. The server is idempotent — later calls with the same ID + content are no-ops, so this pattern also works when the producer later adopts CVT.
+- `registerConsumer(...)` is the step that declares your dependency — only a `schemaId` reference is sent, no schema content.
 
-So in practice: register the schema locally (whether you're the first to do it or not), validate, then call `registerConsumer` to declare your dependency. The producer's CI doing the same doesn't conflict with you.
+In practice: call `useSchema` (or `registerSchema` for greenfield) in `beforeAll` / test setup, validate, then `registerConsumer` to declare your dependency.
 
 ---
 

--- a/docs/reference/architecture/consumer-registry.md
+++ b/docs/reference/architecture/consumer-registry.md
@@ -31,16 +31,23 @@ This produces two symmetrical onboarding flows:
 **Flow A — Producer registers first (typical mature setup)**
 
 1. Producer's CI publishes the OpenAPI spec via `RegisterSchema` on each release.
-2. Consumer's test suite calls `RegisterSchema` on its SDK validator instance (required to bind `schemaId`; idempotent server-side when content matches), then `ValidateInteraction` and `RegisterConsumer` referencing the same `schemaId`.
+2. Consumer's test suite calls **`useSchema(id)`** on its SDK validator — this calls the `GetSchema` RPC, resolves the schema by ID, and pins the validator to the concrete version the server returned. **No local OpenAPI file required.** Then `ValidateInteraction` and `RegisterConsumer` reference the same `schemaId`.
 3. `CanIDeploy` runs on the producer's next release and sees the consumer's registered dependency.
 
 **Flow B — Consumer registers first (greenfield / producer not onboarded)**
 
-1. Consumer obtains the producer's OpenAPI spec and calls `RegisterSchema` itself.
-2. Consumer calls `ValidateInteraction` and `RegisterConsumer` against the schema it just registered.
-3. When the producer later adopts CVT, they register the next schema version. The consumer's registration — associated with the `schemaId`, not the registrant — keeps working across versions.
+1. Consumer obtains a local copy of the producer's OpenAPI spec and calls `RegisterSchema` themselves (via `registerSchema(id, path)`).
+2. Consumer calls `ValidateInteraction` and `RegisterConsumer` against the schema they just registered.
+3. When the producer later adopts CVT, they register the next schema version. The consumer's registration — associated with the `schemaId`, not the registrant — keeps working across versions. The consumer can then switch to `useSchema(id)` to drop the local file.
 
-Only the `RegisterConsumer` call differs in shape: it takes just a `schemaId` reference (no schema content), so it is the one step that never duplicates work regardless of who registered the schema. Both flows converge on the same consumer-registry state, keyed by the `{consumerID, schemaID, environment}` tuple described below.
+SDK method at a glance:
+
+| Method | Requires local file? | Use for |
+|---|---|---|
+| `useSchema(id)` / `useSchema(id, version)` | No | Consumers joining an existing registration (Flow A) |
+| `registerSchema(id, path)` | Yes (path to OpenAPI) | Producers publishing a schema, or consumer-first greenfield (Flow B) |
+
+Only the `RegisterConsumer` call never transmits schema content: it takes just a `schemaId` reference. Both flows converge on the same consumer-registry state, keyed by the `{consumerID, schemaID, environment}` tuple described below.
 
 ## Consumer Registration Flow
 

--- a/sdks/go/cvt/validator.go
+++ b/sdks/go/cvt/validator.go
@@ -184,6 +184,34 @@ type CanIDeployResult struct {
 	AffectedConsumers []ConsumerImpact
 }
 
+// SchemaOwnership contains ownership information for a registered schema.
+type SchemaOwnership struct {
+	Owner        string
+	Team         string
+	ContactEmail string
+	ReadOnly     bool
+}
+
+// SchemaInfo describes a schema resolved via UseSchema.
+type SchemaInfo struct {
+	// SchemaID is the unique identifier for the schema.
+	SchemaID string
+	// SchemaVersion is the concrete semantic version the validator is bound to.
+	SchemaVersion string
+	// SchemaHash is the SHA256 hash of the schema content.
+	SchemaHash string
+	// RegisteredAt is the Unix timestamp of initial registration.
+	RegisteredAt int64
+	// UpdatedAt is the Unix timestamp of last update.
+	UpdatedAt int64
+	// OpenapiVersion is the OpenAPI version detected on the server (e.g., "3.0.0").
+	OpenapiVersion string
+	// EndpointCount is the number of endpoints exposed by the schema.
+	EndpointCount int32
+	// Ownership is optional ownership information.
+	Ownership *SchemaOwnership
+}
+
 // TLSOptions configures TLS for secure connections.
 type TLSOptions struct {
 	// Enabled indicates whether to use TLS.
@@ -213,10 +241,11 @@ type ValidatorOptions struct {
 
 // Validator is a client for validating HTTP interactions against OpenAPI schemas.
 type Validator struct {
-	conn     *grpc.ClientConn
-	client   pb.ContractValidatorClient
-	schemaID string
-	apiKey   string
+	conn          *grpc.ClientConn
+	client        pb.ContractValidatorClient
+	schemaID      string
+	schemaVersion string
+	apiKey        string
 }
 
 // NewValidator creates a new Validator instance with an insecure connection.
@@ -377,6 +406,80 @@ func (v *Validator) RegisterSchema(ctx context.Context, schemaID, schemaPath str
 	return nil
 }
 
+// UseSchema binds the validator to a schema already registered on the server,
+// without requiring a local OpenAPI file. The schema's concrete version is
+// resolved at call time; subsequent Validate calls are pinned to that version.
+//
+// The optional version argument pins to an explicit version. If omitted, the
+// server's latest registered version for this schemaID is used.
+//
+// Returns a SchemaInfo describing the resolved schema.
+//
+// Example:
+//
+//	info, err := validator.UseSchema(ctx, "petstore")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	log.Printf("Bound to %s@%s", info.SchemaID, info.SchemaVersion)
+//	result, _ := validator.Validate(ctx, req, resp)
+func (v *Validator) UseSchema(ctx context.Context, schemaID string, version ...string) (*SchemaInfo, error) {
+	schemaVersion := ""
+	if len(version) > 0 {
+		schemaVersion = version[0]
+	}
+
+	req := &pb.GetSchemaRequest{
+		SchemaId:      schemaID,
+		SchemaVersion: schemaVersion,
+	}
+
+	ctx = v.contextWithAPIKey(ctx)
+
+	resp, err := v.client.GetSchema(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch schema: %w", err)
+	}
+
+	if !resp.Found {
+		if schemaVersion != "" {
+			return nil, fmt.Errorf("schema '%s@%s' not registered on server", schemaID, schemaVersion)
+		}
+		return nil, fmt.Errorf("schema '%s' not registered on server", schemaID)
+	}
+
+	md := resp.Metadata
+	info := &SchemaInfo{
+		SchemaID:       schemaID,
+		SchemaVersion:  "",
+		OpenapiVersion: "",
+		EndpointCount:  0,
+	}
+	if md != nil {
+		if md.SchemaId != "" {
+			info.SchemaID = md.SchemaId
+		}
+		info.SchemaVersion = md.SchemaVersion
+		info.SchemaHash = md.SchemaHash
+		info.RegisteredAt = md.RegisteredAt
+		info.UpdatedAt = md.UpdatedAt
+		info.OpenapiVersion = md.OpenapiVersion
+		info.EndpointCount = md.EndpointCount
+		if md.Ownership != nil {
+			info.Ownership = &SchemaOwnership{
+				Owner:        md.Ownership.Owner,
+				Team:         md.Ownership.Team,
+				ContactEmail: md.Ownership.ContactEmail,
+				ReadOnly:     md.Ownership.ReadOnly,
+			}
+		}
+	}
+
+	v.schemaID = schemaID
+	v.schemaVersion = info.SchemaVersion
+	return info, nil
+}
+
 // Validate validates an HTTP interaction against the registered schema.
 //
 // The request and response parameters should be ValidationRequest and ValidationResponse
@@ -443,6 +546,9 @@ func (v *Validator) Validate(ctx context.Context, request ValidationRequest, res
 		SchemaId: v.schemaID,
 		Request:  requestData,
 		Response: responseData,
+	}
+	if v.schemaVersion != "" {
+		interactionReq.SchemaVersion = v.schemaVersion
 	}
 
 	// Add API key to context if configured

--- a/sdks/go/cvt/validator.go
+++ b/sdks/go/cvt/validator.go
@@ -403,6 +403,7 @@ func (v *Validator) RegisterSchema(ctx context.Context, schemaID, schemaPath str
 	}
 
 	v.schemaID = schemaID
+	v.schemaVersion = ""
 	return nil
 }
 
@@ -612,6 +613,7 @@ func (v *Validator) RegisterSchemaWithVersion(ctx context.Context, schemaID, sch
 	}
 
 	v.schemaID = schemaID
+	v.schemaVersion = ""
 	return nil
 }
 

--- a/sdks/go/cvt/validator_test.go
+++ b/sdks/go/cvt/validator_test.go
@@ -1544,6 +1544,42 @@ func TestValidate_SendsSchemaVersionAfterUseSchema(t *testing.T) {
 	assert.Equal(t, "1.2.0", capturedInteraction.SchemaVersion)
 }
 
+func TestRegisterSchema_ClearsPinAfterUseSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "openapi.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0"}`), 0o600))
+
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	var capturedInteraction *pb.InteractionRequest
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, _ *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			return &pb.GetSchemaResponse{Found: true, Metadata: buildSchemaMetadata()}, nil
+		},
+		registerSchemaFunc: func(_ context.Context, _ *pb.RegisterSchemaRequest, _ ...grpc.CallOption) (*pb.RegisterSchemaResponse, error) {
+			return &pb.RegisterSchemaResponse{Success: true}, nil
+		},
+		validateInteractionFunc: func(_ context.Context, in *pb.InteractionRequest, _ ...grpc.CallOption) (*pb.ValidationResult, error) {
+			capturedInteraction = in
+			return &pb.ValidationResult{Valid: true}, nil
+		},
+	}
+
+	_, err = validator.UseSchema(context.Background(), "petstore")
+	require.NoError(t, err)
+	require.NoError(t, validator.RegisterSchema(context.Background(), "other-schema", schemaPath))
+	_, err = validator.Validate(context.Background(),
+		ValidationRequest{Method: "GET", Path: "/pet/1"},
+		ValidationResponse{StatusCode: 200},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, capturedInteraction)
+	assert.Equal(t, "other-schema", capturedInteraction.SchemaId)
+	assert.Equal(t, "", capturedInteraction.SchemaVersion)
+}
+
 func TestValidate_DoesNotSendVersionAfterRegisterSchema(t *testing.T) {
 	tmpDir := t.TempDir()
 	schemaPath := filepath.Join(tmpDir, "openapi.json")

--- a/sdks/go/cvt/validator_test.go
+++ b/sdks/go/cvt/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -1400,4 +1401,176 @@ func TestContextWithAPIKey(t *testing.T) {
 		// Context should be different since API key is set
 		assert.NotEqual(t, ctx, newCtx)
 	})
+}
+
+func buildSchemaMetadata() *pb.SchemaMetadata {
+	return &pb.SchemaMetadata{
+		SchemaId:       "petstore",
+		SchemaVersion:  "1.2.0",
+		SchemaHash:     "abc123",
+		RegisteredAt:   1714000000,
+		UpdatedAt:      1714000500,
+		OpenapiVersion: "3.0.0",
+		EndpointCount:  7,
+		Ownership: &pb.SchemaOwnership{
+			Owner:        "jane",
+			Team:         "platform",
+			ContactEmail: "platform@example.com",
+			ReadOnly:     false,
+		},
+	}
+}
+
+func TestUseSchema_ResolvesLatest(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	var capturedReq *pb.GetSchemaRequest
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, in *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			capturedReq = in
+			return &pb.GetSchemaResponse{Found: true, Metadata: buildSchemaMetadata()}, nil
+		},
+	}
+
+	info, err := validator.UseSchema(context.Background(), "petstore")
+	require.NoError(t, err)
+	assert.Equal(t, "petstore", capturedReq.SchemaId)
+	assert.Equal(t, "", capturedReq.SchemaVersion)
+	assert.Equal(t, "petstore", info.SchemaID)
+	assert.Equal(t, "1.2.0", info.SchemaVersion)
+	assert.Equal(t, int32(7), info.EndpointCount)
+	require.NotNil(t, info.Ownership)
+	assert.Equal(t, "jane", info.Ownership.Owner)
+	assert.Equal(t, "platform", info.Ownership.Team)
+}
+
+func TestUseSchema_PinsExplicitVersion(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	var capturedReq *pb.GetSchemaRequest
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, in *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			capturedReq = in
+			md := buildSchemaMetadata()
+			md.SchemaVersion = "1.0.0"
+			return &pb.GetSchemaResponse{Found: true, Metadata: md}, nil
+		},
+	}
+
+	info, err := validator.UseSchema(context.Background(), "petstore", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", capturedReq.SchemaVersion)
+	assert.Equal(t, "1.0.0", info.SchemaVersion)
+}
+
+func TestUseSchema_ReturnsErrorWhenNotFound(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, _ *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			return &pb.GetSchemaResponse{Found: false}, nil
+		},
+	}
+
+	_, err = validator.UseSchema(context.Background(), "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'nope'")
+	assert.Contains(t, err.Error(), "not registered")
+}
+
+func TestUseSchema_ErrorIncludesVersionWhenPinning(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, _ *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			return &pb.GetSchemaResponse{Found: false}, nil
+		},
+	}
+
+	_, err = validator.UseSchema(context.Background(), "petstore", "9.9.9")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'petstore@9.9.9'")
+}
+
+func TestUseSchema_PropagatesRPCError(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, _ *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	_, err = validator.UseSchema(context.Background(), "petstore")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestValidate_SendsSchemaVersionAfterUseSchema(t *testing.T) {
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	var capturedInteraction *pb.InteractionRequest
+	validator.client = &mockClient{
+		getSchemasFunc: func(_ context.Context, _ *pb.GetSchemaRequest, _ ...grpc.CallOption) (*pb.GetSchemaResponse, error) {
+			return &pb.GetSchemaResponse{Found: true, Metadata: buildSchemaMetadata()}, nil
+		},
+		validateInteractionFunc: func(_ context.Context, in *pb.InteractionRequest, _ ...grpc.CallOption) (*pb.ValidationResult, error) {
+			capturedInteraction = in
+			return &pb.ValidationResult{Valid: true}, nil
+		},
+	}
+
+	_, err = validator.UseSchema(context.Background(), "petstore")
+	require.NoError(t, err)
+	_, err = validator.Validate(context.Background(),
+		ValidationRequest{Method: "GET", Path: "/pet/1"},
+		ValidationResponse{StatusCode: 200},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, capturedInteraction)
+	assert.Equal(t, "petstore", capturedInteraction.SchemaId)
+	assert.Equal(t, "1.2.0", capturedInteraction.SchemaVersion)
+}
+
+func TestValidate_DoesNotSendVersionAfterRegisterSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "openapi.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{"openapi":"3.0.0"}`), 0o600))
+
+	validator, err := NewValidator("")
+	require.NoError(t, err)
+	defer func() { _ = validator.Close() }()
+
+	var capturedInteraction *pb.InteractionRequest
+	validator.client = &mockClient{
+		registerSchemaFunc: func(_ context.Context, _ *pb.RegisterSchemaRequest, _ ...grpc.CallOption) (*pb.RegisterSchemaResponse, error) {
+			return &pb.RegisterSchemaResponse{Success: true}, nil
+		},
+		validateInteractionFunc: func(_ context.Context, in *pb.InteractionRequest, _ ...grpc.CallOption) (*pb.ValidationResult, error) {
+			capturedInteraction = in
+			return &pb.ValidationResult{Valid: true}, nil
+		},
+	}
+
+	require.NoError(t, validator.RegisterSchema(context.Background(), "test-schema", schemaPath))
+	_, err = validator.Validate(context.Background(),
+		ValidationRequest{Method: "GET", Path: "/pet/1"},
+		ValidationResponse{StatusCode: 200},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, capturedInteraction)
+	assert.Equal(t, "test-schema", capturedInteraction.SchemaId)
+	assert.Equal(t, "", capturedInteraction.SchemaVersion)
 }

--- a/sdks/java/src/main/java/io/github/sahina/sdk/ContractValidator.java
+++ b/sdks/java/src/main/java/io/github/sahina/sdk/ContractValidator.java
@@ -280,6 +280,7 @@ public class ContractValidator implements AutoCloseable {
                 throw new IllegalArgumentException("Schema registration failed: " + response.getMessage());
             }
             this.schemaId = schemaId;
+            this.schemaVersion = null;
         } catch (StatusRuntimeException e) {
             throw new IOException("Failed to register schema: " + e.getStatus(), e);
         }
@@ -440,6 +441,7 @@ public class ContractValidator implements AutoCloseable {
                 throw new IllegalArgumentException("Schema registration failed: " + response.getMessage());
             }
             this.schemaId = schemaId;
+            this.schemaVersion = null;
         } catch (StatusRuntimeException e) {
             throw new IOException("Failed to register schema: " + e.getStatus(), e);
         }

--- a/sdks/java/src/main/java/io/github/sahina/sdk/ContractValidator.java
+++ b/sdks/java/src/main/java/io/github/sahina/sdk/ContractValidator.java
@@ -26,6 +26,8 @@ import io.github.sahina.proto.DeregisterConsumerRequest;
 import io.github.sahina.proto.DeregisterConsumerResponse;
 import io.github.sahina.proto.GenerateFixtureRequest;
 import io.github.sahina.proto.GenerateFixtureResponse;
+import io.github.sahina.proto.GetSchemaRequest;
+import io.github.sahina.proto.GetSchemaResponse;
 import io.github.sahina.proto.InteractionRequest;
 import io.github.sahina.proto.ListConsumersRequest;
 import io.github.sahina.proto.ListConsumersResponse;
@@ -38,6 +40,7 @@ import io.github.sahina.proto.RegisterSchemaRequest;
 import io.github.sahina.proto.RegisterSchemaResponse;
 import io.github.sahina.proto.RequestData;
 import io.github.sahina.proto.ResponseData;
+import io.github.sahina.proto.SchemaMetadata;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -84,6 +87,7 @@ public class ContractValidator implements AutoCloseable {
     private final ManagedChannel channel;
     private final ContractValidatorGrpc.ContractValidatorBlockingStub client;
     private String schemaId;
+    private String schemaVersion;
 
     /**
      * Creates a new ContractValidator instance connecting to the default address
@@ -282,6 +286,73 @@ public class ContractValidator implements AutoCloseable {
     }
 
     /**
+     * Binds the validator to a schema already registered on the server, without
+     * requiring a local OpenAPI file. The schema's concrete version is resolved
+     * at call time; subsequent {@link #validate} calls are pinned to that
+     * version.
+     *
+     * @param schemaId The schema identifier to bind
+     * @return Resolved schema metadata from the server
+     * @throws IllegalArgumentException if the schema is not registered
+     */
+    public SchemaInfo useSchema(String schemaId) {
+        return useSchema(schemaId, null);
+    }
+
+    /**
+     * Binds the validator to a specific version of a schema already registered
+     * on the server, without requiring a local OpenAPI file.
+     *
+     * @param schemaId      The schema identifier to bind
+     * @param schemaVersion Optional version to pin to (null = latest registered)
+     * @return Resolved schema metadata from the server
+     * @throws IllegalArgumentException if the schema or version is not registered
+     */
+    public SchemaInfo useSchema(String schemaId, String schemaVersion) {
+        GetSchemaRequest request = GetSchemaRequest.newBuilder()
+                .setSchemaId(schemaId)
+                .setSchemaVersion(schemaVersion != null ? schemaVersion : "")
+                .build();
+
+        GetSchemaResponse response;
+        try {
+            response = client.getSchema(request);
+        } catch (StatusRuntimeException e) {
+            throw new IllegalStateException("Failed to fetch schema: " + e.getStatus(), e);
+        }
+
+        if (!response.getFound()) {
+            String suffix = (schemaVersion != null && !schemaVersion.isEmpty()) ? "@" + schemaVersion : "";
+            throw new IllegalArgumentException(
+                    "Schema '" + schemaId + suffix + "' not registered on server");
+        }
+
+        SchemaMetadata md = response.getMetadata();
+        String resolvedVersion = md.getSchemaVersion();
+        this.schemaId = schemaId;
+        this.schemaVersion = resolvedVersion;
+
+        SchemaOwnership ownership = null;
+        if (md.hasOwnership()) {
+            ownership = new SchemaOwnership(
+                    md.getOwnership().getOwner(),
+                    md.getOwnership().getTeam(),
+                    md.getOwnership().getContactEmail(),
+                    md.getOwnership().getReadOnly());
+        }
+
+        return new SchemaInfo(
+                md.getSchemaId().isEmpty() ? schemaId : md.getSchemaId(),
+                resolvedVersion,
+                md.getSchemaHash(),
+                md.getRegisteredAt(),
+                md.getUpdatedAt(),
+                md.getOpenapiVersion(),
+                md.getEndpointCount(),
+                ownership);
+    }
+
+    /**
      * Validates an HTTP interaction (request and response) against the registered
      * schema.
      *
@@ -319,11 +390,14 @@ public class ContractValidator implements AutoCloseable {
             responseBuilder.setBody(response.getBody());
         }
 
-        InteractionRequest interactionRequest = InteractionRequest.newBuilder()
+        InteractionRequest.Builder interactionBuilder = InteractionRequest.newBuilder()
                 .setSchemaId(schemaId)
                 .setRequest(requestBuilder)
-                .setResponse(responseBuilder)
-                .build();
+                .setResponse(responseBuilder);
+        if (schemaVersion != null && !schemaVersion.isEmpty()) {
+            interactionBuilder.setSchemaVersion(schemaVersion);
+        }
+        InteractionRequest interactionRequest = interactionBuilder.build();
 
         try {
             io.github.sahina.proto.ValidationResult result = client.validateInteraction(interactionRequest);

--- a/sdks/java/src/main/java/io/github/sahina/sdk/SchemaInfo.java
+++ b/sdks/java/src/main/java/io/github/sahina/sdk/SchemaInfo.java
@@ -1,0 +1,80 @@
+package io.github.sahina.sdk;
+
+/**
+ * Metadata describing a schema resolved via {@link ContractValidator#useSchema}.
+ */
+public class SchemaInfo {
+    private final String schemaId;
+    private final String schemaVersion;
+    private final String schemaHash;
+    private final long registeredAt;
+    private final long updatedAt;
+    private final String openapiVersion;
+    private final int endpointCount;
+    private final SchemaOwnership ownership;
+
+    public SchemaInfo(
+            String schemaId,
+            String schemaVersion,
+            String schemaHash,
+            long registeredAt,
+            long updatedAt,
+            String openapiVersion,
+            int endpointCount,
+            SchemaOwnership ownership) {
+        this.schemaId = schemaId;
+        this.schemaVersion = schemaVersion;
+        this.schemaHash = schemaHash != null ? schemaHash : "";
+        this.registeredAt = registeredAt;
+        this.updatedAt = updatedAt;
+        this.openapiVersion = openapiVersion != null ? openapiVersion : "";
+        this.endpointCount = endpointCount;
+        this.ownership = ownership;
+    }
+
+    public String getSchemaId() {
+        return schemaId;
+    }
+
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public String getSchemaHash() {
+        return schemaHash;
+    }
+
+    public long getRegisteredAt() {
+        return registeredAt;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public String getOpenapiVersion() {
+        return openapiVersion;
+    }
+
+    public int getEndpointCount() {
+        return endpointCount;
+    }
+
+    public SchemaOwnership getOwnership() {
+        return ownership;
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaInfo{" +
+                "schemaId='" + schemaId + '\'' +
+                ", schemaVersion='" + schemaVersion + '\'' +
+                ", schemaHash='" + schemaHash + '\'' +
+                ", registeredAt=" + registeredAt +
+                ", updatedAt=" + updatedAt +
+                ", openapiVersion='" + openapiVersion + '\'' +
+                ", endpointCount=" + endpointCount +
+                ", ownership=" + ownership +
+                '}';
+    }
+}

--- a/sdks/java/src/main/java/io/github/sahina/sdk/SchemaOwnership.java
+++ b/sdks/java/src/main/java/io/github/sahina/sdk/SchemaOwnership.java
@@ -1,0 +1,44 @@
+package io.github.sahina.sdk;
+
+/**
+ * Ownership information for a registered schema.
+ */
+public class SchemaOwnership {
+    private final String owner;
+    private final String team;
+    private final String contactEmail;
+    private final boolean readOnly;
+
+    public SchemaOwnership(String owner, String team, String contactEmail, boolean readOnly) {
+        this.owner = owner != null ? owner : "";
+        this.team = team != null ? team : "";
+        this.contactEmail = contactEmail != null ? contactEmail : "";
+        this.readOnly = readOnly;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getTeam() {
+        return team;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaOwnership{" +
+                "owner='" + owner + '\'' +
+                ", team='" + team + '\'' +
+                ", contactEmail='" + contactEmail + '\'' +
+                ", readOnly=" + readOnly +
+                '}';
+    }
+}

--- a/sdks/java/src/test/java/io/github/sahina/sdk/ContractValidatorTest.java
+++ b/sdks/java/src/test/java/io/github/sahina/sdk/ContractValidatorTest.java
@@ -9,6 +9,8 @@ import io.github.sahina.proto.DeregisterConsumerRequest;
 import io.github.sahina.proto.DeregisterConsumerResponse;
 import io.github.sahina.proto.GenerateFixtureRequest;
 import io.github.sahina.proto.GenerateFixtureResponse;
+import io.github.sahina.proto.GetSchemaRequest;
+import io.github.sahina.proto.GetSchemaResponse;
 import io.github.sahina.proto.InteractionRequest;
 import io.github.sahina.proto.ListConsumersRequest;
 import io.github.sahina.proto.ListConsumersResponse;
@@ -19,6 +21,8 @@ import io.github.sahina.proto.RegisterConsumerRequest;
 import io.github.sahina.proto.RegisterConsumerResponse;
 import io.github.sahina.proto.RegisterSchemaRequest;
 import io.github.sahina.proto.RegisterSchemaResponse;
+import io.github.sahina.proto.SchemaMetadata;
+import io.github.sahina.proto.SchemaOwnership;
 import io.github.sahina.proto.ValidationResult;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -1088,5 +1092,188 @@ class ContractValidatorTest {
         assertEquals(201, response.getStatusCode());
         assertEquals("application/json", response.getHeaders().get("Content-Type"));
         assertNotNull(response.getBody());
+    }
+
+    // ============================================================================
+    // useSchema tests
+    // ============================================================================
+
+    private SchemaMetadata buildSchemaMetadata() {
+        return buildSchemaMetadata("1.2.0", true);
+    }
+
+    private SchemaMetadata buildSchemaMetadata(String version, boolean withOwnership) {
+        SchemaMetadata.Builder b = SchemaMetadata.newBuilder()
+                .setSchemaId("petstore")
+                .setSchemaVersion(version)
+                .setSchemaHash("abc123")
+                .setRegisteredAt(1714000000L)
+                .setUpdatedAt(1714000500L)
+                .setOpenapiVersion("3.0.0")
+                .setEndpointCount(7);
+        if (withOwnership) {
+            b.setOwnership(SchemaOwnership.newBuilder()
+                    .setOwner("jane")
+                    .setTeam("platform")
+                    .setContactEmail("platform@example.com")
+                    .setReadOnly(false)
+                    .build());
+        }
+        return b.build();
+    }
+
+    @Test
+    @DisplayName("useSchema resolves latest and returns SchemaInfo")
+    void testUseSchemaResolvesLatest() {
+        GetSchemaResponse response = GetSchemaResponse.newBuilder()
+                .setFound(true)
+                .setMetadata(buildSchemaMetadata())
+                .build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(response);
+
+        SchemaInfo info = validator.useSchema("petstore");
+
+        ArgumentCaptor<GetSchemaRequest> captor = ArgumentCaptor.forClass(GetSchemaRequest.class);
+        verify(mockStub).getSchema(captor.capture());
+        assertEquals("petstore", captor.getValue().getSchemaId());
+        assertEquals("", captor.getValue().getSchemaVersion());
+
+        assertEquals("petstore", info.getSchemaId());
+        assertEquals("1.2.0", info.getSchemaVersion());
+        assertEquals(7, info.getEndpointCount());
+        assertNotNull(info.getOwnership());
+        assertEquals("jane", info.getOwnership().getOwner());
+        assertEquals("platform", info.getOwnership().getTeam());
+    }
+
+    @Test
+    @DisplayName("useSchema pins to an explicit version")
+    void testUseSchemaPinsVersion() {
+        GetSchemaResponse response = GetSchemaResponse.newBuilder()
+                .setFound(true)
+                .setMetadata(buildSchemaMetadata("1.0.0", false))
+                .build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(response);
+
+        SchemaInfo info = validator.useSchema("petstore", "1.0.0");
+
+        ArgumentCaptor<GetSchemaRequest> captor = ArgumentCaptor.forClass(GetSchemaRequest.class);
+        verify(mockStub).getSchema(captor.capture());
+        assertEquals("1.0.0", captor.getValue().getSchemaVersion());
+        assertEquals("1.0.0", info.getSchemaVersion());
+    }
+
+    @Test
+    @DisplayName("useSchema throws when schema is not registered")
+    void testUseSchemaNotFound() {
+        GetSchemaResponse response = GetSchemaResponse.newBuilder().setFound(false).build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(response);
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> validator.useSchema("nope"));
+        assertTrue(e.getMessage().contains("'nope'"));
+        assertTrue(e.getMessage().contains("not registered"));
+    }
+
+    @Test
+    @DisplayName("useSchema error message includes version when pinning")
+    void testUseSchemaNotFoundWithVersion() {
+        GetSchemaResponse response = GetSchemaResponse.newBuilder().setFound(false).build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(response);
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> validator.useSchema("petstore", "9.9.9"));
+        assertTrue(e.getMessage().contains("'petstore@9.9.9'"));
+    }
+
+    @Test
+    @DisplayName("useSchema propagates gRPC errors")
+    void testUseSchemaPropagatesRpcError() {
+        when(mockStub.getSchema(any(GetSchemaRequest.class)))
+                .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
+
+        assertThrows(IllegalStateException.class, () -> validator.useSchema("petstore"));
+    }
+
+    @Test
+    @DisplayName("validate() sends schema_version after useSchema")
+    void testValidateSendsVersionAfterUseSchema() {
+        GetSchemaResponse getResponse = GetSchemaResponse.newBuilder()
+                .setFound(true)
+                .setMetadata(buildSchemaMetadata())
+                .build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(getResponse);
+        when(mockStub.validateInteraction(any(InteractionRequest.class)))
+                .thenReturn(ValidationResult.newBuilder().setValid(true).build());
+
+        validator.useSchema("petstore");
+        validator.validate(
+                ValidationRequest.builder().method("GET").path("/pet/1").build(),
+                ValidationResponse.builder().statusCode(200).build());
+
+        ArgumentCaptor<InteractionRequest> captor = ArgumentCaptor.forClass(InteractionRequest.class);
+        verify(mockStub).validateInteraction(captor.capture());
+        assertEquals("petstore", captor.getValue().getSchemaId());
+        assertEquals("1.2.0", captor.getValue().getSchemaVersion());
+    }
+
+    @Test
+    @DisplayName("SchemaOwnership getters and toString")
+    void testSchemaOwnershipGetters() {
+        io.github.sahina.sdk.SchemaOwnership o = new io.github.sahina.sdk.SchemaOwnership(
+                "jane", "platform", "platform@example.com", true);
+        assertEquals("jane", o.getOwner());
+        assertEquals("platform", o.getTeam());
+        assertEquals("platform@example.com", o.getContactEmail());
+        assertTrue(o.isReadOnly());
+        assertTrue(o.toString().contains("jane"));
+
+        io.github.sahina.sdk.SchemaOwnership nullCoalesced =
+                new io.github.sahina.sdk.SchemaOwnership(null, null, null, false);
+        assertEquals("", nullCoalesced.getOwner());
+        assertEquals("", nullCoalesced.getTeam());
+        assertEquals("", nullCoalesced.getContactEmail());
+        assertFalse(nullCoalesced.isReadOnly());
+    }
+
+    @Test
+    @DisplayName("SchemaInfo getters and toString")
+    void testSchemaInfoGetters() {
+        io.github.sahina.sdk.SchemaOwnership ownership =
+                new io.github.sahina.sdk.SchemaOwnership("jane", "platform", "", false);
+        SchemaInfo info = new SchemaInfo("petstore", "1.2.0", "abc123", 100L, 200L, "3.0.0", 7, ownership);
+        assertEquals("petstore", info.getSchemaId());
+        assertEquals("1.2.0", info.getSchemaVersion());
+        assertEquals("abc123", info.getSchemaHash());
+        assertEquals(100L, info.getRegisteredAt());
+        assertEquals(200L, info.getUpdatedAt());
+        assertEquals("3.0.0", info.getOpenapiVersion());
+        assertEquals(7, info.getEndpointCount());
+        assertSame(ownership, info.getOwnership());
+        assertTrue(info.toString().contains("petstore"));
+
+        SchemaInfo nullCoalesced = new SchemaInfo("x", "1.0", null, 0L, 0L, null, 0, null);
+        assertEquals("", nullCoalesced.getSchemaHash());
+        assertEquals("", nullCoalesced.getOpenapiVersion());
+        assertNull(nullCoalesced.getOwnership());
+    }
+
+    @Test
+    @DisplayName("validate() does NOT send schema_version after registerSchema only")
+    void testValidateDoesNotSendVersionAfterRegisterSchema() throws IOException {
+        when(mockStub.registerSchema(any(RegisterSchemaRequest.class)))
+                .thenReturn(RegisterSchemaResponse.newBuilder().setSuccess(true).build());
+        when(mockStub.validateInteraction(any(InteractionRequest.class)))
+                .thenReturn(ValidationResult.newBuilder().setValid(true).build());
+
+        validator.registerSchema("test-schema", "path/to/schema.json");
+        validator.validate(
+                ValidationRequest.builder().method("GET").path("/pet/1").build(),
+                ValidationResponse.builder().statusCode(200).build());
+
+        ArgumentCaptor<InteractionRequest> captor = ArgumentCaptor.forClass(InteractionRequest.class);
+        verify(mockStub).validateInteraction(captor.capture());
+        assertEquals("test-schema", captor.getValue().getSchemaId());
+        assertEquals("", captor.getValue().getSchemaVersion());
     }
 }

--- a/sdks/java/src/test/java/io/github/sahina/sdk/ContractValidatorTest.java
+++ b/sdks/java/src/test/java/io/github/sahina/sdk/ContractValidatorTest.java
@@ -1259,6 +1259,31 @@ class ContractValidatorTest {
     }
 
     @Test
+    @DisplayName("registerSchema after useSchema clears the version pin")
+    void testRegisterSchemaClearsPinAfterUseSchema() throws IOException {
+        GetSchemaResponse getResponse = GetSchemaResponse.newBuilder()
+                .setFound(true)
+                .setMetadata(buildSchemaMetadata())
+                .build();
+        when(mockStub.getSchema(any(GetSchemaRequest.class))).thenReturn(getResponse);
+        when(mockStub.registerSchema(any(RegisterSchemaRequest.class)))
+                .thenReturn(RegisterSchemaResponse.newBuilder().setSuccess(true).build());
+        when(mockStub.validateInteraction(any(InteractionRequest.class)))
+                .thenReturn(ValidationResult.newBuilder().setValid(true).build());
+
+        validator.useSchema("petstore");
+        validator.registerSchema("other-schema", "path/to/schema.json");
+        validator.validate(
+                ValidationRequest.builder().method("GET").path("/pet/1").build(),
+                ValidationResponse.builder().statusCode(200).build());
+
+        ArgumentCaptor<InteractionRequest> captor = ArgumentCaptor.forClass(InteractionRequest.class);
+        verify(mockStub).validateInteraction(captor.capture());
+        assertEquals("other-schema", captor.getValue().getSchemaId());
+        assertEquals("", captor.getValue().getSchemaVersion());
+    }
+
+    @Test
     @DisplayName("validate() does NOT send schema_version after registerSchema only")
     void testValidateDoesNotSendVersionAfterRegisterSchema() throws IOException {
         when(mockStub.registerSchema(any(RegisterSchemaRequest.class)))

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -388,6 +388,7 @@ export class ContractValidator {
             reject(new Error(response.message));
           } else {
             this.schemaId = schemaId;
+            this.schemaVersion = null;
             resolve();
           }
         },
@@ -509,7 +510,9 @@ export class ContractValidator {
     response: ValidationResponse<ResBody>,
   ): Promise<ValidationResult> {
     if (!this.schemaId) {
-      throw new Error("Schema not registered. Call registerSchema first.");
+      throw new Error(
+        "Schema not bound. Call registerSchema or useSchema first.",
+      );
     }
 
     const interactionRequest: any = {
@@ -580,6 +583,7 @@ export class ContractValidator {
             reject(new Error(response.message));
           } else {
             this.schemaId = schemaId;
+            this.schemaVersion = null;
             resolve();
           }
         },
@@ -672,7 +676,9 @@ export class ContractValidator {
     options: GenerateOptions = {},
   ): Promise<GeneratedFixture> {
     if (!this.schemaId) {
-      throw new Error("Schema not registered. Call registerSchema first.");
+      throw new Error(
+        "Schema not bound. Call registerSchema or useSchema first.",
+      );
     }
 
     return new Promise((resolve, reject) => {
@@ -735,7 +741,9 @@ export class ContractValidator {
     options: GenerateOptions = {},
   ): Promise<GeneratedResponse> {
     if (!this.schemaId) {
-      throw new Error("Schema not registered. Call registerSchema first.");
+      throw new Error(
+        "Schema not bound. Call registerSchema or useSchema first.",
+      );
     }
 
     return new Promise((resolve, reject) => {
@@ -786,7 +794,9 @@ export class ContractValidator {
     options: GenerateOptions = {},
   ): Promise<any> {
     if (!this.schemaId) {
-      throw new Error("Schema not registered. Call registerSchema first.");
+      throw new Error(
+        "Schema not bound. Call registerSchema or useSchema first.",
+      );
     }
 
     return new Promise((resolve, reject) => {
@@ -828,7 +838,9 @@ export class ContractValidator {
    */
   async listEndpoints(): Promise<EndpointInfo[]> {
     if (!this.schemaId) {
-      throw new Error("Schema not registered. Call registerSchema first.");
+      throw new Error(
+        "Schema not bound. Call registerSchema or useSchema first.",
+      );
     }
 
     return new Promise((resolve, reject) => {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -244,12 +244,45 @@ export interface CanIDeployResult {
 }
 
 /**
+ * Ownership information for a registered schema.
+ */
+export interface SchemaOwnership {
+  owner: string;
+  team: string;
+  contactEmail: string;
+  readOnly: boolean;
+}
+
+/**
+ * Metadata describing a schema resolved via useSchema.
+ */
+export interface SchemaInfo {
+  /** Unique identifier for the schema. */
+  schemaId: string;
+  /** Concrete semantic version the validator is bound to. */
+  schemaVersion: string;
+  /** SHA256 hash of the schema content. */
+  schemaHash: string;
+  /** Unix timestamp of initial registration. */
+  registeredAt: number;
+  /** Unix timestamp of last update. */
+  updatedAt: number;
+  /** Optional ownership information. */
+  ownership?: SchemaOwnership;
+  /** OpenAPI version detected on the server (e.g., "3.0.0"). */
+  openapiVersion: string;
+  /** Number of endpoints exposed by the schema. */
+  endpointCount: number;
+}
+
+/**
  * Client for the Contract Validator Toolkit (CVT).
  * Allows validating HTTP interactions against OpenAPI schemas via a gRPC service.
  */
 export class ContractValidator {
   private client: any;
   private schemaId: string | null = null;
+  private schemaVersion: string | null = null;
   private apiKey: string | undefined;
 
   /**
@@ -362,6 +395,76 @@ export class ContractValidator {
     });
   }
 
+  /**
+   * Binds the validator to a schema already registered on the server, without
+   * requiring a local OpenAPI file. Resolves the schema's concrete version at
+   * call time; subsequent validate() calls are pinned to that version.
+   *
+   * @param schemaId - The schema identifier to bind.
+   * @param schemaVersion - Optional version to pin to (default: latest registered).
+   * @returns Resolved schema metadata from the server.
+   * @throws Error if the schema (or specific version) is not registered.
+   *
+   * @example
+   * const validator = new ContractValidator("localhost:9550");
+   * const info = await validator.useSchema("petstore");
+   * console.log(`Bound to ${info.schemaId}@${info.schemaVersion}`);
+   * await validator.validate(req, resp);
+   */
+  async useSchema(
+    schemaId: string,
+    schemaVersion?: string,
+  ): Promise<SchemaInfo> {
+    return new Promise((resolve, reject) => {
+      this.client.GetSchema(
+        {
+          schema_id: schemaId,
+          schema_version: schemaVersion || "",
+        },
+        this.createMetadata(),
+        (err: any, response: any) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          if (!response.found) {
+            const suffix = schemaVersion ? `@${schemaVersion}` : "";
+            reject(
+              new Error(
+                `Schema '${schemaId}${suffix}' not registered on server`,
+              ),
+            );
+            return;
+          }
+
+          const metadata = response.metadata || {};
+          const resolvedVersion: string = metadata.schema_version || "";
+          this.schemaId = schemaId;
+          this.schemaVersion = resolvedVersion;
+
+          const info: SchemaInfo = {
+            schemaId: metadata.schema_id || schemaId,
+            schemaVersion: resolvedVersion,
+            schemaHash: metadata.schema_hash || "",
+            registeredAt: Number(metadata.registered_at) || 0,
+            updatedAt: Number(metadata.updated_at) || 0,
+            openapiVersion: metadata.openapi_version || "",
+            endpointCount: Number(metadata.endpoint_count) || 0,
+          };
+          if (metadata.ownership) {
+            info.ownership = {
+              owner: metadata.ownership.owner || "",
+              team: metadata.ownership.team || "",
+              contactEmail: metadata.ownership.contact_email || "",
+              readOnly: Boolean(metadata.ownership.read_only),
+            };
+          }
+          resolve(info);
+        },
+      );
+    });
+  }
+
   private async fetchSchemaFromUrl(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
       const client = url.startsWith("https://") ? https : http;
@@ -409,7 +512,7 @@ export class ContractValidator {
       throw new Error("Schema not registered. Call registerSchema first.");
     }
 
-    const interactionRequest = {
+    const interactionRequest: any = {
       schema_id: this.schemaId,
       request: {
         method: request.method,
@@ -423,6 +526,9 @@ export class ContractValidator {
         body: response.body ? JSON.stringify(response.body) : "",
       },
     };
+    if (this.schemaVersion) {
+      interactionRequest.schema_version = this.schemaVersion;
+    }
 
     return new Promise((resolve, reject) => {
       this.client.ValidateInteraction(

--- a/sdks/node/tests/contract-validator.test.ts
+++ b/sdks/node/tests/contract-validator.test.ts
@@ -314,7 +314,7 @@ describe("ContractValidator", () => {
           { method: "GET", path: "/" },
           { statusCode: 200 },
         ),
-      ).rejects.toThrow("Schema not registered");
+      ).rejects.toThrow("Schema not bound");
     });
   });
 
@@ -771,7 +771,7 @@ describe("ContractValidator", () => {
 
       await expect(
         newValidator.generateFixture("GET", "/users"),
-      ).rejects.toThrow("Schema not registered");
+      ).rejects.toThrow("Schema not bound");
     });
 
     it("should handle generateFixture failure response", async () => {
@@ -959,7 +959,7 @@ describe("ContractValidator", () => {
       const newValidator = new ContractValidator();
       await expect(
         newValidator.generateResponse("GET", "/users"),
-      ).rejects.toThrow("Schema not registered");
+      ).rejects.toThrow("Schema not bound");
     });
 
     it("should reject on failure response", async () => {
@@ -1023,7 +1023,7 @@ describe("ContractValidator", () => {
       const newValidator = new ContractValidator();
       await expect(
         newValidator.generateRequestBody("POST", "/users"),
-      ).rejects.toThrow("Schema not registered");
+      ).rejects.toThrow("Schema not bound");
     });
 
     it("should reject on failure response", async () => {
@@ -1142,6 +1142,32 @@ describe("ContractValidator", () => {
       const sent = mockValidateInteraction.mock.calls[0][0];
       expect(sent.schema_id).toBe("petstore");
       expect(sent.schema_version).toBe("1.2.0");
+    });
+
+    it("clears version pin when registerSchema rebinds after useSchema", async () => {
+      mockGetSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { found: true, metadata: metadataFixture });
+      });
+      mockRegisterSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { success: true });
+      });
+      mockValidateInteraction.mockImplementation(
+        (_req: any, _md: any, cb: any) => {
+          cb(null, { valid: true, errors: [] });
+        },
+      );
+
+      await validator.useSchema("petstore");
+      const schemaPath = path.resolve(__dirname, "../../shared/openapi.json");
+      await validator.registerSchema("other-schema", schemaPath);
+      await validator.validate(
+        { method: "GET", path: "/pet/1" },
+        { statusCode: 200 },
+      );
+
+      const sent = mockValidateInteraction.mock.calls[0][0];
+      expect(sent.schema_id).toBe("other-schema");
+      expect(sent.schema_version).toBeUndefined();
     });
 
     it("does NOT send schema_version when only registerSchema was called", async () => {

--- a/sdks/node/tests/contract-validator.test.ts
+++ b/sdks/node/tests/contract-validator.test.ts
@@ -19,6 +19,7 @@ const mockRegisterConsumer = jest.fn();
 const mockListConsumers = jest.fn();
 const mockDeregisterConsumer = jest.fn();
 const mockCanIDeploy = jest.fn();
+const mockGetSchema = jest.fn();
 
 jest.mock("@grpc/grpc-js", () => {
   // Define MockMetadata inside the factory to avoid hoisting issues
@@ -71,6 +72,7 @@ describe("ContractValidator", () => {
     mockListConsumers.mockReset();
     mockDeregisterConsumer.mockReset();
     mockCanIDeploy.mockReset();
+    mockGetSchema.mockReset();
     jest.clearAllMocks();
 
     // Create validator
@@ -88,6 +90,7 @@ describe("ContractValidator", () => {
       ListConsumers: mockListConsumers,
       DeregisterConsumer: mockDeregisterConsumer,
       CanIDeploy: mockCanIDeploy,
+      GetSchema: mockGetSchema,
     };
   });
 
@@ -1036,6 +1039,131 @@ describe("ContractValidator", () => {
       await expect(
         validator.generateRequestBody("POST", "/users"),
       ).rejects.toThrow("Generation failed");
+    });
+  });
+
+  describe("useSchema", () => {
+    const metadataFixture = {
+      schema_id: "petstore",
+      schema_version: "1.2.0",
+      schema_hash: "abc123",
+      registered_at: 1714000000,
+      updated_at: 1714000500,
+      openapi_version: "3.0.0",
+      endpoint_count: 7,
+      ownership: {
+        owner: "jane",
+        team: "platform",
+        contact_email: "platform@example.com",
+        read_only: false,
+      },
+    };
+
+    it("resolves latest version and returns SchemaInfo", async () => {
+      mockGetSchema.mockImplementation((req: any, _md: any, cb: any) => {
+        expect(req.schema_id).toBe("petstore");
+        expect(req.schema_version).toBe("");
+        cb(null, { found: true, metadata: metadataFixture });
+      });
+
+      const info = await validator.useSchema("petstore");
+
+      expect(info.schemaId).toBe("petstore");
+      expect(info.schemaVersion).toBe("1.2.0");
+      expect(info.openapiVersion).toBe("3.0.0");
+      expect(info.endpointCount).toBe(7);
+      expect(info.ownership).toEqual({
+        owner: "jane",
+        team: "platform",
+        contactEmail: "platform@example.com",
+        readOnly: false,
+      });
+    });
+
+    it("pins to an explicit version", async () => {
+      mockGetSchema.mockImplementation((req: any, _md: any, cb: any) => {
+        expect(req.schema_version).toBe("1.0.0");
+        cb(null, {
+          found: true,
+          metadata: { ...metadataFixture, schema_version: "1.0.0" },
+        });
+      });
+
+      const info = await validator.useSchema("petstore", "1.0.0");
+      expect(info.schemaVersion).toBe("1.0.0");
+    });
+
+    it("throws a clear error when schema is not registered", async () => {
+      mockGetSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { found: false });
+      });
+
+      await expect(validator.useSchema("nope")).rejects.toThrow(
+        /'nope'.*not registered/,
+      );
+    });
+
+    it("includes the version in the error when pinning", async () => {
+      mockGetSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { found: false });
+      });
+
+      await expect(validator.useSchema("petstore", "9.9.9")).rejects.toThrow(
+        /'petstore@9\.9\.9'/,
+      );
+    });
+
+    it("propagates gRPC errors from GetSchema", async () => {
+      mockGetSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(new Error("Connection refused"), null);
+      });
+
+      await expect(validator.useSchema("petstore")).rejects.toThrow(
+        "Connection refused",
+      );
+    });
+
+    it("causes validate() to send schema_version after useSchema", async () => {
+      mockGetSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { found: true, metadata: metadataFixture });
+      });
+      mockValidateInteraction.mockImplementation(
+        (_req: any, _md: any, cb: any) => {
+          cb(null, { valid: true, errors: [] });
+        },
+      );
+
+      await validator.useSchema("petstore");
+      await validator.validate(
+        { method: "GET", path: "/pet/1" },
+        { statusCode: 200 },
+      );
+
+      const sent = mockValidateInteraction.mock.calls[0][0];
+      expect(sent.schema_id).toBe("petstore");
+      expect(sent.schema_version).toBe("1.2.0");
+    });
+
+    it("does NOT send schema_version when only registerSchema was called", async () => {
+      mockRegisterSchema.mockImplementation((_req: any, _md: any, cb: any) => {
+        cb(null, { success: true });
+      });
+      mockValidateInteraction.mockImplementation(
+        (_req: any, _md: any, cb: any) => {
+          cb(null, { valid: true, errors: [] });
+        },
+      );
+
+      const schemaPath = path.resolve(__dirname, "../../shared/openapi.json");
+      await validator.registerSchema("test-schema", schemaPath);
+      await validator.validate(
+        { method: "GET", path: "/pet/1" },
+        { statusCode: 200 },
+      );
+
+      const sent = mockValidateInteraction.mock.calls[0][0];
+      expect(sent.schema_id).toBe("test-schema");
+      expect(sent.schema_version).toBeUndefined();
     });
   });
 });

--- a/sdks/python/cvt_sdk/__init__.py
+++ b/sdks/python/cvt_sdk/__init__.py
@@ -16,6 +16,7 @@ import grpc
 from .proto import (
     ContractValidatorStub,
     RegisterSchemaRequest,
+    GetSchemaRequest,
     InteractionRequest,
     RequestData,
     ResponseData,
@@ -284,6 +285,30 @@ class CanIDeployResult(TypedDict):
     """Impact on each affected consumer."""
 
 
+@dataclass
+class SchemaOwnership:
+    """Ownership information for a registered schema."""
+
+    owner: str = ""
+    team: str = ""
+    contact_email: str = ""
+    read_only: bool = False
+
+
+@dataclass
+class SchemaInfo:
+    """Metadata describing a schema resolved via use_schema()."""
+
+    schema_id: str
+    schema_version: str
+    schema_hash: str = ""
+    registered_at: int = 0
+    updated_at: int = 0
+    openapi_version: str = ""
+    endpoint_count: int = 0
+    ownership: Optional[SchemaOwnership] = None
+
+
 class ContractValidator:
     """
     Client for the Contract Validator Toolkit (CVT).
@@ -335,6 +360,7 @@ class ContractValidator:
 
         self._client = ContractValidatorStub(self._channel)
         self._schema_id: Optional[str] = None
+        self._schema_version: Optional[str] = None
 
     def _create_tls_credentials(
         self, tls_options: TLSOptions
@@ -396,6 +422,65 @@ class ContractValidator:
 
         self._schema_id = schema_id
 
+    def use_schema(
+        self, schema_id: str, schema_version: Optional[str] = None
+    ) -> SchemaInfo:
+        """
+        Binds the validator to a schema already registered on the server, without
+        requiring a local OpenAPI file. The schema's concrete version is resolved
+        at call time; subsequent validate() calls are pinned to that version.
+
+        Args:
+            schema_id: The schema identifier to bind.
+            schema_version: Optional version to pin to (default: latest registered).
+
+        Returns:
+            A SchemaInfo describing the resolved schema.
+
+        Raises:
+            ValueError: If the schema (or specific version) is not registered.
+
+        Example:
+            >>> validator = ContractValidator("localhost:9550")
+            >>> info = validator.use_schema("petstore")
+            >>> print(f"Bound to {info.schema_id}@{info.schema_version}")
+            >>> validator.validate(request, response)
+        """
+        request = GetSchemaRequest(
+            schema_id=schema_id,
+            schema_version=schema_version or "",
+        )
+        response = self._client.GetSchema(request, metadata=self._create_metadata())
+
+        if not response.found:
+            suffix = f"@{schema_version}" if schema_version else ""
+            raise ValueError(f"Schema '{schema_id}{suffix}' not registered on server")
+
+        metadata = response.metadata
+        resolved_version = metadata.schema_version
+        self._schema_id = schema_id
+        self._schema_version = resolved_version
+
+        ownership: Optional[SchemaOwnership] = None
+        if metadata.HasField("ownership"):
+            ownership = SchemaOwnership(
+                owner=metadata.ownership.owner,
+                team=metadata.ownership.team,
+                contact_email=metadata.ownership.contact_email,
+                read_only=metadata.ownership.read_only,
+            )
+
+        return SchemaInfo(
+            schema_id=metadata.schema_id or schema_id,
+            schema_version=resolved_version,
+            schema_hash=metadata.schema_hash,
+            registered_at=metadata.registered_at,
+            updated_at=metadata.updated_at,
+            openapi_version=metadata.openapi_version,
+            endpoint_count=metadata.endpoint_count,
+            ownership=ownership,
+        )
+
     def validate(
         self, request: ValidationRequest, response: ValidationResponse
     ) -> ValidationResult:
@@ -432,9 +517,14 @@ class ContractValidator:
         )
 
         # Validate interaction
-        interaction_request = InteractionRequest(
-            schema_id=self._schema_id, request=request_data, response=response_data
-        )
+        interaction_kwargs: Dict[str, Any] = {
+            "schema_id": self._schema_id,
+            "request": request_data,
+            "response": response_data,
+        }
+        if self._schema_version:
+            interaction_kwargs["schema_version"] = self._schema_version
+        interaction_request = InteractionRequest(**interaction_kwargs)
         result: ProtoValidationResult = self._client.ValidateInteraction(
             interaction_request, metadata=self._create_metadata()
         )

--- a/sdks/python/cvt_sdk/__init__.py
+++ b/sdks/python/cvt_sdk/__init__.py
@@ -421,6 +421,7 @@ class ContractValidator:
             raise ValueError(f"Schema registration failed: {response.message}")
 
         self._schema_id = schema_id
+        self._schema_version = None
 
     def use_schema(
         self, schema_id: str, schema_version: Optional[str] = None
@@ -564,6 +565,7 @@ class ContractValidator:
             raise ValueError(f"Schema registration failed: {response.message}")
 
         self._schema_id = schema_id
+        self._schema_version = None
 
     def compare_schemas(
         self, schema_id: str, old_version: str = "", new_version: str = ""
@@ -1148,6 +1150,8 @@ __all__ = [
     "RegisterConsumerOptions",
     "ConsumerImpact",
     "CanIDeployResult",
+    "SchemaOwnership",
+    "SchemaInfo",
 ]
 
 # Re-export auto-register types (must be at end to avoid circular imports)

--- a/sdks/python/cvt_sdk/proto/__init__.py
+++ b/sdks/python/cvt_sdk/proto/__init__.py
@@ -3,6 +3,10 @@
 from .cvt_pb2 import (
     RegisterSchemaRequest,
     RegisterSchemaResponse,
+    GetSchemaRequest,
+    GetSchemaResponse,
+    SchemaMetadata,
+    SchemaOwnership as ProtoSchemaOwnership,
     InteractionRequest,
     ValidationResult,
     RequestData,
@@ -39,6 +43,10 @@ from .cvt_pb2_grpc import ContractValidatorStub
 __all__ = [
     "RegisterSchemaRequest",
     "RegisterSchemaResponse",
+    "GetSchemaRequest",
+    "GetSchemaResponse",
+    "SchemaMetadata",
+    "ProtoSchemaOwnership",
     "InteractionRequest",
     "ValidationResult",
     "RequestData",

--- a/sdks/python/tests/test_contract_validator.py
+++ b/sdks/python/tests/test_contract_validator.py
@@ -458,3 +458,131 @@ class TestCanIDeploy:
         assert result["safe_to_deploy"] is False
         assert len(result["affected_consumers"]) == 1
         assert result["affected_consumers"][0]["consumer_id"] == "order-service"
+
+
+class TestUseSchema:
+    """Tests for the use_schema() method."""
+
+    @staticmethod
+    def _build_metadata_mock(
+        schema_id: str = "petstore",
+        schema_version: str = "1.2.0",
+        with_ownership: bool = True,
+    ):
+        metadata = MagicMock()
+        metadata.schema_id = schema_id
+        metadata.schema_version = schema_version
+        metadata.schema_hash = "abc123"
+        metadata.registered_at = 1714000000
+        metadata.updated_at = 1714000500
+        metadata.openapi_version = "3.0.0"
+        metadata.endpoint_count = 7
+        metadata.HasField = lambda name: name == "ownership" and with_ownership
+        metadata.ownership.owner = "jane"
+        metadata.ownership.team = "platform"
+        metadata.ownership.contact_email = "platform@example.com"
+        metadata.ownership.read_only = False
+        return metadata
+
+    def test_resolves_latest_version(self, validator):
+        """use_schema(id) returns resolved SchemaInfo and binds latest version."""
+        metadata = self._build_metadata_mock()
+        response = MagicMock()
+        response.found = True
+        response.metadata = metadata
+        validator._client.GetSchema.return_value = response
+
+        info = validator.use_schema("petstore")
+
+        args = validator._client.GetSchema.call_args[0][0]
+        assert args.schema_id == "petstore"
+        assert args.schema_version == ""
+        assert info.schema_id == "petstore"
+        assert info.schema_version == "1.2.0"
+        assert info.endpoint_count == 7
+        assert info.ownership is not None
+        assert info.ownership.owner == "jane"
+        assert info.ownership.team == "platform"
+
+    def test_pins_explicit_version(self, validator):
+        """use_schema(id, version) passes version through to GetSchema."""
+        metadata = self._build_metadata_mock(schema_version="1.0.0")
+        response = MagicMock()
+        response.found = True
+        response.metadata = metadata
+        validator._client.GetSchema.return_value = response
+
+        info = validator.use_schema("petstore", "1.0.0")
+
+        args = validator._client.GetSchema.call_args[0][0]
+        assert args.schema_version == "1.0.0"
+        assert info.schema_version == "1.0.0"
+
+    def test_raises_when_schema_not_found(self, validator):
+        """use_schema raises ValueError when server returns found=False."""
+        response = MagicMock()
+        response.found = False
+        validator._client.GetSchema.return_value = response
+
+        with pytest.raises(ValueError, match="'nope'.*not registered"):
+            validator.use_schema("nope")
+
+    def test_error_message_includes_version_when_pinning(self, validator):
+        """Error message mentions the pinned version."""
+        response = MagicMock()
+        response.found = False
+        validator._client.GetSchema.return_value = response
+
+        with pytest.raises(ValueError, match=r"'petstore@9\.9\.9'"):
+            validator.use_schema("petstore", "9.9.9")
+
+    def test_validate_sends_schema_version_after_use_schema(self, validator):
+        """validate() sends schema_version on the wire after use_schema()."""
+        metadata = self._build_metadata_mock()
+        get_response = MagicMock()
+        get_response.found = True
+        get_response.metadata = metadata
+        validator._client.GetSchema.return_value = get_response
+
+        validation_response = MagicMock(spec=ValidationResult)
+        validation_response.valid = True
+        validation_response.errors = []
+        validator._client.ValidateInteraction.return_value = validation_response
+
+        validator.use_schema("petstore")
+        validator.validate(
+            request=ValidationRequest(method="GET", path="/pet/1"),
+            response=ValidationResponse(status_code=200),
+        )
+
+        sent = validator._client.ValidateInteraction.call_args[0][0]
+        assert sent.schema_id == "petstore"
+        assert sent.schema_version == "1.2.0"
+
+    def test_validate_does_not_send_version_after_register_schema(
+        self, validator, schema_path
+    ):
+        """Existing register_schema path must not start sending schema_version."""
+        mock_reg = MagicMock(spec=RegisterSchemaResponse)
+        mock_reg.success = True
+        validator._client.RegisterSchema.return_value = mock_reg
+
+        validation_response = MagicMock(spec=ValidationResult)
+        validation_response.valid = True
+        validation_response.errors = []
+        validator._client.ValidateInteraction.return_value = validation_response
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "read_text", return_value='{"openapi": "3.0.0"}'),
+        ):
+            validator.register_schema("test-schema", schema_path)
+
+        validator.validate(
+            request=ValidationRequest(method="GET", path="/pet/1"),
+            response=ValidationResponse(status_code=200),
+        )
+
+        sent = validator._client.ValidateInteraction.call_args[0][0]
+        assert sent.schema_id == "test-schema"
+        assert sent.schema_version == ""

--- a/sdks/python/tests/test_contract_validator.py
+++ b/sdks/python/tests/test_contract_validator.py
@@ -9,6 +9,8 @@ from cvt_sdk import (
     ValidationRequest,
     ValidationResponse,
     RegisterConsumerOptions,
+    SchemaInfo,
+    SchemaOwnership,
 )
 from cvt_sdk.proto import RegisterSchemaResponse, ValidationResult
 
@@ -460,6 +462,18 @@ class TestCanIDeploy:
         assert result["affected_consumers"][0]["consumer_id"] == "order-service"
 
 
+class TestSchemaInfoExports:
+    """Regression: SchemaInfo / SchemaOwnership must be in the public API."""
+
+    def test_schema_info_importable(self):
+        info = SchemaInfo(schema_id="x", schema_version="1.0")
+        assert info.schema_id == "x"
+
+    def test_schema_ownership_importable(self):
+        o = SchemaOwnership(owner="jane", team="platform")
+        assert o.owner == "jane"
+
+
 class TestUseSchema:
     """Tests for the use_schema() method."""
 
@@ -558,6 +572,39 @@ class TestUseSchema:
         sent = validator._client.ValidateInteraction.call_args[0][0]
         assert sent.schema_id == "petstore"
         assert sent.schema_version == "1.2.0"
+
+    def test_register_schema_clears_pin_after_use_schema(self, validator, schema_path):
+        """register_schema after use_schema must clear the version pin."""
+        metadata = self._build_metadata_mock()
+        get_response = MagicMock()
+        get_response.found = True
+        get_response.metadata = metadata
+        validator._client.GetSchema.return_value = get_response
+
+        mock_reg = MagicMock(spec=RegisterSchemaResponse)
+        mock_reg.success = True
+        validator._client.RegisterSchema.return_value = mock_reg
+
+        validation_response = MagicMock(spec=ValidationResult)
+        validation_response.valid = True
+        validation_response.errors = []
+        validator._client.ValidateInteraction.return_value = validation_response
+
+        validator.use_schema("petstore")
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "read_text", return_value='{"openapi": "3.0.0"}'),
+        ):
+            validator.register_schema("other-schema", schema_path)
+
+        validator.validate(
+            request=ValidationRequest(method="GET", path="/pet/1"),
+            response=ValidationResponse(status_code=200),
+        )
+
+        sent = validator._client.ValidateInteraction.call_args[0][0]
+        assert sent.schema_id == "other-schema"
+        assert sent.schema_version == ""
 
     def test_validate_does_not_send_version_after_register_schema(
         self, validator, schema_path


### PR DESCRIPTION
## Summary

- Adds `useSchema(schemaId, version?)` to all four SDKs (Node.js, Python, Go, Java) — consumers can now bind a validator to an already-registered schema via the existing `GetSchema` RPC, **no local OpenAPI file required**.
- Resolves the concrete version at call time and pins `validate()` to that `(schema_id, schema_version)` tuple; returns resolved `SchemaInfo` (id, version, hash, ownership, endpoint count, timestamps).
- Existing `registerSchema()` behavior is untouched — `validate()` only sends `schema_version` on the wire when `useSchema` was used.
- Flow A docs rewritten across `faq.md`, `consumer-testing.mdx`, `can-i-deploy.mdx`, and `consumer-registry.md` to recommend `useSchema` for consumers joining an existing registration vs. `registerSchema` for publishing/greenfield.

Closes #120.

## Test plan

- [x] `make test-node-sdk` — 239 passing (+7 new)
- [x] `make test-python-sdk` — 209 passing (+6 new)
- [x] `make test-go-sdk` — passing (+7 new, `UseSchema` 100%, `Validate` 95.8%)
- [x] `make test-java-sdk` — 205 passing (+9 new, `SchemaInfo` / `SchemaOwnership` 100%)
- [x] `make ci` — all lint + format checks green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `useSchema()` method enables validators to resolve and bind to server-registered schemas without requiring local OpenAPI files
  * Optional schema version pinning with `useSchema(id, version)` for explicit version control
  * Schema metadata now accessible, including ownership and registration timestamps

* **Documentation**
  * Clarified two distinct onboarding flows for schema consumers
  * Enhanced FAQ, guides, and examples with explicit best practices and flow recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->